### PR TITLE
Loop the loading GIF

### DIFF
--- a/src/components/CoursePane/CoursePane.js
+++ b/src/components/CoursePane/CoursePane.js
@@ -140,7 +140,7 @@ class CoursePane extends Component {
             alignItems: "center"
           }}
         >
-          <video autoPlay>
+          <video autoplay loop>
             <source src={loadingGif} type="video/mp4"/>
           </video>
         </div>


### PR DESCRIPTION
The loading GIF should be looped especially when loading takes longer than the length of the GIF/video.