### PR TITLE
Bug Fix: Department Search Bar

### DIFF
--- a/src/components/SearchForm/DeptSearchBar/DeptSearchBar.js
+++ b/src/components/SearchForm/DeptSearchBar/DeptSearchBar.js
@@ -78,6 +78,8 @@ class DeptSearchBar extends React.Component {
 
       this.setState({ history: copy_history }); //add search to front
       window.localStorage.setItem('history', JSON.stringify(copy_history));
+    } else {
+      this.props.setDept(null);
     }
   };
 

--- a/src/components/SearchForm/SearchForm.js
+++ b/src/components/SearchForm/SearchForm.js
@@ -132,7 +132,7 @@ class SearchForm extends Component {
   };
 
   setDept = (dept) => {
-    if (dept == null) this.setState({ dept: null });
+    if (dept == null) this.setState({ dept: null, label: null });
     else this.setState({ dept: dept.value, label: dept.label });
   };
 


### PR DESCRIPTION
Fixed a glitch where the department could not be cleared in the search form.
Also updated setDept to clear the department search label when set to null.