### PR TITLE
style: match schedule popover drag handle gray to icon buttons

### DIFF
--- a/apps/antalmanac/src/components/Calendar/Toolbar/ScheduleSelect/drag-and-drop/DragHandle.tsx
+++ b/apps/antalmanac/src/components/Calendar/Toolbar/ScheduleSelect/drag-and-drop/DragHandle.tsx
@@ -1,7 +1,6 @@
 import { SortableItemContext } from '$components/Calendar/Toolbar/ScheduleSelect/drag-and-drop/SortableItem';
-import { useThemeStore } from '$stores/SettingsStore';
 import DragIndicatorIcon from '@mui/icons-material/DragIndicator';
-import { Box } from '@mui/material';
+import { Box, useTheme } from '@mui/material';
 import { useContext } from 'react';
 
 interface DragHandleProps {
@@ -10,7 +9,7 @@ interface DragHandleProps {
 
 export function DragHandle({ disabled = false }: DragHandleProps) {
     const { attributes, listeners, ref } = useContext(SortableItemContext);
-    const isDark = useThemeStore((store) => store.isDark);
+    const theme = useTheme();
 
     return (
         <Box
@@ -24,7 +23,7 @@ export function DragHandle({ disabled = false }: DragHandleProps) {
                 cursor: disabled ? 'auto' : 'pointer',
                 borderRadius: 1,
                 '&:hover': {
-                    backgroundColor: disabled ? 'transparent' : 'rgba(0, 0, 0, 0.1)',
+                    backgroundColor: disabled ? 'transparent' : theme.palette.action.hover,
                 },
                 '&:focus-visible': {
                     boxShadow: disabled ? 'none' : '0 0 0 2px #4c9ffe',
@@ -33,7 +32,7 @@ export function DragHandle({ disabled = false }: DragHandleProps) {
         >
             <DragIndicatorIcon
                 sx={{
-                    color: disabled ? 'gray' : !isDark ? 'black' : 'white',
+                    color: disabled ? theme.palette.action.disabled : theme.palette.action.active,
                 }}
             />
         </Box>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The schedule select popover drag handle used pure black/white for the grip icon, so it did not match the default MUI `IconButton` icons (copy, rename, delete) which use the theme action palette grays.

The drag indicator now uses `theme.palette.action.active` and `action.disabled` when the handle is inactive, matching default icon buttons in both light and dark mode. The hover background uses `action.hover` for parity with `IconButton` hover states.

## Test Plan

- [ ] Open calendar schedule dropdown; confirm drag grip matches adjacent icon button gray in light mode.
- [ ] Repeat in dark mode.
- [ ] With fallback/read-only mode, confirm disabled drag handle matches disabled icon styling.

## Issues

Closes #
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bc713666-c601-457c-a3ee-001345b685df"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bc713666-c601-457c-a3ee-001345b685df"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

