### PR TITLE
fix: improve accessibility

### DIFF
--- a/apps/antalmanac/src/components/Header/ProfileMenuButtons.tsx
+++ b/apps/antalmanac/src/components/Header/ProfileMenuButtons.tsx
@@ -27,7 +27,12 @@ export function ProfileMenuButtons({ user, handleOpen, handleSettingsOpen, loadi
                 >
                     Sign In
                 </Button>
-                <IconButton onClick={handleSettingsOpen} color="inherit">
+                <IconButton
+                    onClick={handleSettingsOpen}
+                    color="inherit"
+                    aria-label="Open settings menu"
+                    aria-haspopup="true"
+                >
                     <Menu sx={{ width: 24, height: 24 }} />
                 </IconButton>
             </>

--- a/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/Footer.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/Footer.tsx
@@ -6,7 +6,7 @@ import { ProjectsButton } from '$components/buttons/ProjectsButton';
 
 export const Footer = () => {
     return (
-        <Stack direction="row" justifyContent="center" color="grey">
+        <Stack direction="row" justifyContent="center" sx={{ color: 'text.secondary' }}>
             <ProjectsButton />
             <GitHubButton />
             <FeedbackButton />


### PR DESCRIPTION
Add aria-label and aria-haspopup on the header settings IconButton. Use theme text.secondary for footer links instead of inherited grey.

## Summary

## Test Plan

## Issues

Closes #

<!-- [Optional]
## Future Followup
-->
