### PR TITLE
fix: deploy term data — drop cached generated/termData.ts + lib cleanup

### DIFF
--- a/apps/antalmanac/scripts/fetch-term-data.ts
+++ b/apps/antalmanac/scripts/fetch-term-data.ts
@@ -80,6 +80,16 @@ async function main() {
     await mkdir(GENERATED_DIR, { recursive: true });
     await writeFile(TERM_DATA_FILE, JSON.stringify(termEntries, null, 2));
 
+    /** Old pipelines emitted `termData.ts` under `src/generated`; Actions cache restores that tree, so remove it (see icssc/AntAlmanac@3ad7c407). */
+    const staleGeneratedTermDataTs = join(GENERATED_DIR, 'termData.ts');
+    try {
+        await rm(staleGeneratedTermDataTs);
+    } catch (e) {
+        if ((e as NodeJS.ErrnoException).code !== 'ENOENT') {
+            throw e;
+        }
+    }
+
     console.log('Term data generated. Written to ', TERM_DATA_FILE);
 }
 

--- a/apps/antalmanac/scripts/fetch-term-data.ts
+++ b/apps/antalmanac/scripts/fetch-term-data.ts
@@ -1,11 +1,11 @@
 import 'dotenv/config';
-import { mkdir, unlink, writeFile } from 'node:fs/promises';
+import { mkdir, writeFile } from 'node:fs/promises';
 
 import { AATerm } from '@packages/antalmanac-types';
 import { createClient } from '@packages/anteater-api/client';
 import type { CalendarTerm, Quarter, Year } from '@packages/anteater-api/types';
 
-import { GENERATED_DIR, LEGACY_TERM_DATA_TS, TERM_DATA_FILE } from './lib/paths.js';
+import { GENERATED_DIR, TERM_DATA_FILE } from './lib/paths.js';
 
 const aapiClient = createClient({ apiKey: process.env.ANTEATER_API_KEY });
 
@@ -41,20 +41,7 @@ function serializeTerm(term: CalendarTerm) {
     };
 }
 
-async function removeLegacyTermDataTs() {
-    try {
-        await unlink(LEGACY_TERM_DATA_TS);
-        console.log(`Removed legacy ${LEGACY_TERM_DATA_TS} (replaced by term.ts + generated termData.json).`);
-    } catch (e) {
-        if ((e as NodeJS.ErrnoException).code !== 'ENOENT') {
-            throw e;
-        }
-    }
-}
-
 async function main() {
-    await removeLegacyTermDataTs();
-
     console.log('Fetching all calendar terms from Anteater API...');
     const calendarTerms = await aapiClient.calendar.all();
     console.log(`Fetched ${calendarTerms.length} calendar terms.`);

--- a/apps/antalmanac/scripts/fetch-term-data.ts
+++ b/apps/antalmanac/scripts/fetch-term-data.ts
@@ -1,11 +1,19 @@
 import 'dotenv/config';
-import { mkdir, writeFile } from 'node:fs/promises';
+import { mkdir, rm, writeFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 import { AATerm } from '@packages/antalmanac-types';
 import { createClient } from '@packages/anteater-api/client';
 import type { CalendarTerm, Quarter, Year } from '@packages/anteater-api/types';
 
 import { GENERATED_DIR, TERM_DATA_FILE } from './lib/paths.js';
+
+/** Package root: derive from this file (`…/scripts/fetch-term-data.ts`), not `paths.ts`, so tooling cannot point `import.meta.url` at a different tree than `apps/antalmanac`. */
+const ANTALMANAC_ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
+const LEGACY_TERM_DATA_FILES = ['termData.ts', 'termData.js', 'termData.d.ts'].map((name) =>
+    join(ANTALMANAC_ROOT, 'src/lib', name)
+);
 
 const aapiClient = createClient({ apiKey: process.env.ANTEATER_API_KEY });
 
@@ -41,7 +49,22 @@ function serializeTerm(term: CalendarTerm) {
     };
 }
 
+async function removeLegacyTermDataFiles() {
+    for (const filePath of LEGACY_TERM_DATA_FILES) {
+        try {
+            await rm(filePath);
+            console.log(`Removed legacy ${filePath} (replaced by term.ts + generated termData.json).`);
+        } catch (e) {
+            if ((e as NodeJS.ErrnoException).code !== 'ENOENT') {
+                throw e;
+            }
+        }
+    }
+}
+
 async function main() {
+    await removeLegacyTermDataFiles();
+
     console.log('Fetching all calendar terms from Anteater API...');
     const calendarTerms = await aapiClient.calendar.all();
     console.log(`Fetched ${calendarTerms.length} calendar terms.`);

--- a/apps/antalmanac/scripts/lib/paths.ts
+++ b/apps/antalmanac/scripts/lib/paths.ts
@@ -11,5 +11,3 @@ export const TERM_DATA_FILE = join(GENERATED_DIR, 'termData.json');
 export const DEPARTMENTS_FILE = join(GENERATED_DIR, 'departments.json');
 export const SEARCH_DATA_FILE = join(GENERATED_DIR, 'searchData.json');
 export const DEPLOYED_TERMS_FILE = join(GENERATED_DIR, 'deployed_terms.json');
-/** Pre-refactor source file; safe to remove if present after migrating to `term.ts` + generated JSON. */
-export const LEGACY_TERM_DATA_TS = join(appRoot, 'src/lib/termData.ts');

--- a/apps/antalmanac/src/stores/ReviewPromptStore.ts
+++ b/apps/antalmanac/src/stores/ReviewPromptStore.ts
@@ -53,7 +53,7 @@ export const useReviewPromptStore = create(
             const today = new Date();
 
             // Collect past terms within the window (termData is ordered newest-first
-            // after the filter in termData.ts — see its `filter(socAvailable <= today)`).
+            // after the filter in term.ts — see its `filter(socAvailable <= today)`).
             // We further filter to terms whose finals have already ended.
             const pastTermNames = new Set<string>(
                 termData


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Deploy failure (root cause)

`.github/actions/cache-generated-data` restores **`apps/antalmanac/src/generated`**. Older pipelines sometimes left **`src/generated/termData.ts`** next to `termData.json`. After #1784, `term.ts` imports **`$generated/termData.json`**, but a leftover **`termData.ts`** in the same folder can confuse module resolution / TypeScript and break `next build` / deploy.

The follow-up that only `unlink`’d **`src/lib/termData.ts`** never removed the cached **`src/generated/termData.ts`**, so the bad file kept coming back from cache.

The fix that already worked on a branch is [3ad7c407](https://github.com/icssc/AntAlmanac/commit/3ad7c4077d313fb888b9f44662d60094f21fcb43): after writing `termData.json`, delete **`join(GENERATED_DIR, 'termData.ts')`**.

This PR restores that behavior (using `fs.rm` like the rest of the script) and keeps the other cleanups:

- Remove stale **`src/lib/termData.{ts,js,d.ts}`** using the **entry script’s** `import.meta.url` (avoids a wrong root when `paths.ts` resolves oddly).
- Drop `LEGACY_TERM_DATA_TS` from `paths.ts`.
- Review prompt comment points at `term.ts`.

## Test plan

- [x] `pnpm lint`
- [x] Confirmed `fetch-term-data` removes a dummy `src/generated/termData.ts` after JSON write (manual smoke).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6552bc54-bfe5-4f9d-a1e8-86d7eb6792ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6552bc54-bfe5-4f9d-a1e8-86d7eb6792ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

