### PR TITLE
Revert "fix: deploy term data — drop cached generated/termData.ts + lib cleanup"

### DIFF
--- a/apps/antalmanac/scripts/fetch-term-data.ts
+++ b/apps/antalmanac/scripts/fetch-term-data.ts
@@ -1,19 +1,11 @@
 import 'dotenv/config';
-import { mkdir, rm, writeFile } from 'node:fs/promises';
-import { dirname, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { mkdir, unlink, writeFile } from 'node:fs/promises';
 
 import { AATerm } from '@packages/antalmanac-types';
 import { createClient } from '@packages/anteater-api/client';
 import type { CalendarTerm, Quarter, Year } from '@packages/anteater-api/types';
 
-import { GENERATED_DIR, TERM_DATA_FILE } from './lib/paths.js';
-
-/** Package root: derive from this file (`…/scripts/fetch-term-data.ts`), not `paths.ts`, so tooling cannot point `import.meta.url` at a different tree than `apps/antalmanac`. */
-const ANTALMANAC_ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
-const LEGACY_TERM_DATA_FILES = ['termData.ts', 'termData.js', 'termData.d.ts'].map((name) =>
-    join(ANTALMANAC_ROOT, 'src/lib', name)
-);
+import { GENERATED_DIR, LEGACY_TERM_DATA_TS, TERM_DATA_FILE } from './lib/paths.js';
 
 const aapiClient = createClient({ apiKey: process.env.ANTEATER_API_KEY });
 
@@ -49,21 +41,19 @@ function serializeTerm(term: CalendarTerm) {
     };
 }
 
-async function removeLegacyTermDataFiles() {
-    for (const filePath of LEGACY_TERM_DATA_FILES) {
-        try {
-            await rm(filePath);
-            console.log(`Removed legacy ${filePath} (replaced by term.ts + generated termData.json).`);
-        } catch (e) {
-            if ((e as NodeJS.ErrnoException).code !== 'ENOENT') {
-                throw e;
-            }
+async function removeLegacyTermDataTs() {
+    try {
+        await unlink(LEGACY_TERM_DATA_TS);
+        console.log(`Removed legacy ${LEGACY_TERM_DATA_TS} (replaced by term.ts + generated termData.json).`);
+    } catch (e) {
+        if ((e as NodeJS.ErrnoException).code !== 'ENOENT') {
+            throw e;
         }
     }
 }
 
 async function main() {
-    await removeLegacyTermDataFiles();
+    await removeLegacyTermDataTs();
 
     console.log('Fetching all calendar terms from Anteater API...');
     const calendarTerms = await aapiClient.calendar.all();
@@ -79,16 +69,6 @@ async function main() {
 
     await mkdir(GENERATED_DIR, { recursive: true });
     await writeFile(TERM_DATA_FILE, JSON.stringify(termEntries, null, 2));
-
-    /** Old pipelines emitted `termData.ts` under `src/generated`; Actions cache restores that tree, so remove it (see icssc/AntAlmanac@3ad7c407). */
-    const staleGeneratedTermDataTs = join(GENERATED_DIR, 'termData.ts');
-    try {
-        await rm(staleGeneratedTermDataTs);
-    } catch (e) {
-        if ((e as NodeJS.ErrnoException).code !== 'ENOENT') {
-            throw e;
-        }
-    }
 
     console.log('Term data generated. Written to ', TERM_DATA_FILE);
 }

--- a/apps/antalmanac/scripts/lib/paths.ts
+++ b/apps/antalmanac/scripts/lib/paths.ts
@@ -11,3 +11,5 @@ export const TERM_DATA_FILE = join(GENERATED_DIR, 'termData.json');
 export const DEPARTMENTS_FILE = join(GENERATED_DIR, 'departments.json');
 export const SEARCH_DATA_FILE = join(GENERATED_DIR, 'searchData.json');
 export const DEPLOYED_TERMS_FILE = join(GENERATED_DIR, 'deployed_terms.json');
+/** Pre-refactor source file; safe to remove if present after migrating to `term.ts` + generated JSON. */
+export const LEGACY_TERM_DATA_TS = join(appRoot, 'src/lib/termData.ts');

--- a/apps/antalmanac/src/stores/ReviewPromptStore.ts
+++ b/apps/antalmanac/src/stores/ReviewPromptStore.ts
@@ -53,7 +53,7 @@ export const useReviewPromptStore = create(
             const today = new Date();
 
             // Collect past terms within the window (termData is ordered newest-first
-            // after the filter in term.ts — see its `filter(socAvailable <= today)`).
+            // after the filter in termData.ts — see its `filter(socAvailable <= today)`).
             // We further filter to terms whose finals have already ended.
             const pastTermNames = new Set<string>(
                 termData


### PR DESCRIPTION
Reverts icssc/AntAlmanac#1790