### PR TITLE
Quick search: roadmap as shortcut under search, add COMPSCI shortcut

### DIFF
--- a/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/QuickSearch.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/QuickSearch.tsx
@@ -1,8 +1,9 @@
 import FuzzySearch from '$components/RightPane/CoursePane/SearchForm/FuzzySearch';
 import { SearchWithPlanner } from '$components/RightPane/CoursePane/SearchForm/SearchWithPlanner';
-import { Box, Stack, Typography, useTheme } from '@mui/material';
+import RightPaneStore from '$components/RightPane/RightPaneStore';
+import { Box, Button, Stack } from '@mui/material';
 import { usePostHog } from 'posthog-js/react';
-import { ComponentProps } from 'react';
+import { ComponentProps, useCallback } from 'react';
 
 interface QuickSearchProps {
     toggleSearch: ComponentProps<typeof FuzzySearch>['toggleSearch'];
@@ -11,8 +12,14 @@ interface QuickSearchProps {
 
 export const QuickSearch = ({ toggleSearch, labelProps }: QuickSearchProps) => {
     const postHog = usePostHog();
-    const theme = useTheme();
-    const quickSearchStack = `@container quick-search (max-width: ${theme.breakpoints.values.sm}px)`;
+
+    const runCompsciShortcut = useCallback(() => {
+        const term = RightPaneStore.getFormData().term;
+        RightPaneStore.resetFormValues();
+        RightPaneStore.setTerm(term);
+        RightPaneStore.updateFormValue('deptValue', 'COMPSCI');
+        toggleSearch();
+    }, [toggleSearch]);
 
     return (
         <Box
@@ -22,44 +29,20 @@ export const QuickSearch = ({ toggleSearch, labelProps }: QuickSearchProps) => {
                 minWidth: 0,
             }}
         >
-            <Stack direction="row" flexWrap="wrap" alignItems="center" gap={2} useFlexGap sx={{ minWidth: 0 }}>
-                <Box
-                    sx={{
-                        flex: '2 1 200px',
-                        minWidth: 'min(100%, 200px)',
-                        maxWidth: '100%',
-                        [quickSearchStack]: {
-                            flex: '1 1 100%',
-                            minWidth: 0,
-                        },
-                    }}
-                >
-                    <FuzzySearch toggleSearch={toggleSearch} postHog={postHog} labelProps={labelProps} />
-                </Box>
-                <Typography
-                    component="span"
-                    sx={{
-                        flexShrink: 0,
-                        [quickSearchStack]: {
-                            display: 'none',
-                        },
-                    }}
-                >
-                    or
-                </Typography>
-                <Box
-                    sx={{
-                        flex: '1 1 180px',
-                        minWidth: 'min(100%, 180px)',
-                        maxWidth: '100%',
-                        [quickSearchStack]: {
-                            flex: '1 1 100%',
-                            minWidth: 0,
-                        },
-                    }}
-                >
-                    <SearchWithPlanner labelProps={labelProps} />
-                </Box>
+            <Stack spacing={1} sx={{ minWidth: 0 }}>
+                <FuzzySearch toggleSearch={toggleSearch} postHog={postHog} labelProps={labelProps} />
+                <Stack direction="row" alignItems="stretch" gap={1} flexWrap="wrap" useFlexGap sx={{ minWidth: 0 }}>
+                    <SearchWithPlanner />
+                    <Button
+                        variant="outlined"
+                        size="small"
+                        color="secondary"
+                        onClick={runCompsciShortcut}
+                        sx={{ flex: '1 1 0', minWidth: 'min(100%, 140px)', maxWidth: '100%' }}
+                    >
+                        COMPSCI
+                    </Button>
+                </Stack>
             </Stack>
         </Box>
     );

--- a/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/QuickSearch.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/QuickSearch.tsx
@@ -1,9 +1,13 @@
+import { GE_LIST, QUICK_SEARCH_SHORTCUT_PILL_SX } from '$components/RightPane/CoursePane/SearchForm/constants';
 import FuzzySearch from '$components/RightPane/CoursePane/SearchForm/FuzzySearch';
 import { SearchWithPlanner } from '$components/RightPane/CoursePane/SearchForm/SearchWithPlanner';
 import RightPaneStore from '$components/RightPane/RightPaneStore';
-import { Box, Button, Stack } from '@mui/material';
+import { School, Search } from '@mui/icons-material';
+import { Box, Button, Stack, Typography } from '@mui/material';
 import { usePostHog } from 'posthog-js/react';
 import { ComponentProps, useCallback } from 'react';
+
+const GE3_ENTRY = GE_LIST.find((g) => g.value === 'GE-3');
 
 interface QuickSearchProps {
     toggleSearch: ComponentProps<typeof FuzzySearch>['toggleSearch'];
@@ -21,6 +25,17 @@ export const QuickSearch = ({ toggleSearch, labelProps }: QuickSearchProps) => {
         toggleSearch();
     }, [toggleSearch]);
 
+    const runGe3Shortcut = useCallback(() => {
+        if (!GE3_ENTRY) {
+            return;
+        }
+        const term = RightPaneStore.getFormData().term;
+        RightPaneStore.resetFormValues();
+        RightPaneStore.setTerm(term);
+        RightPaneStore.updateFormValue('ge', GE3_ENTRY.value);
+        toggleSearch();
+    }, [toggleSearch]);
+
     return (
         <Box
             sx={{
@@ -31,16 +46,48 @@ export const QuickSearch = ({ toggleSearch, labelProps }: QuickSearchProps) => {
         >
             <Stack spacing={1} sx={{ minWidth: 0 }}>
                 <FuzzySearch toggleSearch={toggleSearch} postHog={postHog} labelProps={labelProps} />
-                <Stack direction="row" alignItems="stretch" gap={1} flexWrap="wrap" useFlexGap sx={{ minWidth: 0 }}>
+                <Stack
+                    direction="row"
+                    alignItems="stretch"
+                    gap={1}
+                    flexWrap="nowrap"
+                    sx={{ minWidth: 0, width: '100%' }}
+                >
                     <SearchWithPlanner />
                     <Button
                         variant="outlined"
                         size="small"
                         color="secondary"
                         onClick={runCompsciShortcut}
-                        sx={{ flex: '1 1 0', minWidth: 'min(100%, 140px)', maxWidth: '100%' }}
+                        startIcon={<Search fontSize="small" />}
+                        sx={QUICK_SEARCH_SHORTCUT_PILL_SX}
                     >
-                        COMPSCI
+                        <Typography
+                            component="span"
+                            variant="body2"
+                            noWrap
+                            sx={{ flex: '1 1 auto', minWidth: 0, textAlign: 'left' }}
+                        >
+                            COMPSCI
+                        </Typography>
+                    </Button>
+                    <Button
+                        variant="outlined"
+                        size="small"
+                        color="secondary"
+                        onClick={runGe3Shortcut}
+                        disabled={!GE3_ENTRY}
+                        startIcon={<School fontSize="small" />}
+                        sx={QUICK_SEARCH_SHORTCUT_PILL_SX}
+                    >
+                        <Typography
+                            component="span"
+                            variant="body2"
+                            noWrap
+                            sx={{ flex: '1 1 auto', minWidth: 0, textAlign: 'left' }}
+                        >
+                            {GE3_ENTRY?.shortLabel ?? 'GE III (3)'}
+                        </Typography>
                     </Button>
                 </Stack>
             </Stack>

--- a/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/SearchWithPlanner.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/SearchWithPlanner.tsx
@@ -261,13 +261,11 @@ export const SearchWithPlanner = () => {
             endIcon={<KeyboardArrowDown sx={{ flexShrink: 0 }} />}
             aria-haspopup="true"
             aria-expanded={menuOpen ? 'true' : undefined}
-            sx={[
-                QUICK_SEARCH_SHORTCUT_PILL_SX,
-                {
-                    width: '100%',
-                    '& .MuiButton-endIcon': { marginLeft: 'auto', flexShrink: 0 },
-                },
-            ]}
+            sx={{
+                ...QUICK_SEARCH_SHORTCUT_PILL_SX,
+                width: '100%',
+                '& .MuiButton-endIcon': { marginLeft: 'auto', flexShrink: 0 },
+            }}
         >
             <Typography
                 component="span"

--- a/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/SearchWithPlanner.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/SearchWithPlanner.tsx
@@ -1,5 +1,8 @@
 import { SignInDialog } from '$components/dialogs/SignInDialog';
-import { PLANNER_SEARCH_PARAM } from '$components/RightPane/CoursePane/SearchForm/constants';
+import {
+    PLANNER_SEARCH_PARAM,
+    QUICK_SEARCH_SHORTCUT_PILL_SX,
+} from '$components/RightPane/CoursePane/SearchForm/constants';
 import { CreateRoadmapLinkItem } from '$components/RightPane/CoursePane/SearchForm/CreateRoadmapLinkItem';
 import RightPaneStore from '$components/RightPane/RightPaneStore';
 import trpc from '$lib/api/trpc';
@@ -14,7 +17,7 @@ import { useCoursePaneStore } from '$stores/CoursePaneStore';
 import { usePlannerStore } from '$stores/PlannerStore';
 import { useSessionStore } from '$stores/SessionStore';
 import { openSnackbar } from '$stores/SnackbarStore';
-import { KeyboardArrowDown, OpenInBrowser } from '@mui/icons-material';
+import { EventNote, KeyboardArrowDown, OpenInBrowser } from '@mui/icons-material';
 import { Box, Button, IconButton, ListSubheader, Menu, MenuItem, Tooltip, Typography } from '@mui/material';
 import { Roadmap } from '@packages/antalmanac-types';
 import { useSearchParams } from 'next/navigation';
@@ -254,12 +257,26 @@ export const SearchWithPlanner = () => {
             color="secondary"
             disabled={isLoadingSearch}
             onClick={handleRoadmapButtonClick}
-            endIcon={<KeyboardArrowDown />}
+            startIcon={<EventNote fontSize="small" />}
+            endIcon={<KeyboardArrowDown sx={{ flexShrink: 0 }} />}
             aria-haspopup="true"
             aria-expanded={menuOpen ? 'true' : undefined}
-            sx={{ flex: '1 1 0', minWidth: 'min(100%, 140px)', maxWidth: '100%' }}
+            sx={[
+                QUICK_SEARCH_SHORTCUT_PILL_SX,
+                {
+                    width: '100%',
+                    '& .MuiButton-endIcon': { marginLeft: 'auto', flexShrink: 0 },
+                },
+            ]}
         >
-            {isLoadingSearch ? 'Loading…' : isPlannerLoading ? 'Roadmaps…' : 'Roadmap'}
+            <Typography
+                component="span"
+                variant="body2"
+                noWrap
+                sx={{ flex: '1 1 auto', minWidth: 0, textAlign: 'left' }}
+            >
+                {isLoadingSearch ? 'Loading…' : isPlannerLoading ? 'Roadmaps…' : 'Roadmap'}
+            </Typography>
         </Button>
     );
 

--- a/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/SearchWithPlanner.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/SearchWithPlanner.tsx
@@ -1,8 +1,6 @@
 import { SignInDialog } from '$components/dialogs/SignInDialog';
-import { HorizontalRightDivider } from '$components/HorizontalRightDivider';
 import { PLANNER_SEARCH_PARAM } from '$components/RightPane/CoursePane/SearchForm/constants';
 import { CreateRoadmapLinkItem } from '$components/RightPane/CoursePane/SearchForm/CreateRoadmapLinkItem';
-import { LabeledAutocomplete } from '$components/RightPane/CoursePane/SearchForm/LabeledInputs/LabeledAutocomplete';
 import RightPaneStore from '$components/RightPane/RightPaneStore';
 import trpc from '$lib/api/trpc';
 import {
@@ -16,18 +14,12 @@ import { useCoursePaneStore } from '$stores/CoursePaneStore';
 import { usePlannerStore } from '$stores/PlannerStore';
 import { useSessionStore } from '$stores/SessionStore';
 import { openSnackbar } from '$stores/SnackbarStore';
-import { OpenInBrowser } from '@mui/icons-material';
-import { Box, IconButton, MenuItem, Tooltip, Typography } from '@mui/material';
+import { KeyboardArrowDown, OpenInBrowser } from '@mui/icons-material';
+import { Box, Button, IconButton, ListSubheader, Menu, MenuItem, Tooltip, Typography } from '@mui/material';
 import { Roadmap } from '@packages/antalmanac-types';
 import { useSearchParams } from 'next/navigation';
-import { ComponentProps, HTMLAttributes, useCallback, useEffect, useMemo, useState } from 'react';
+import { type MouseEvent, type ReactNode, useCallback, useEffect, useMemo, useState } from 'react';
 import { useShallow } from 'zustand/react/shallow';
-
-interface SearchWithPlannerProps {
-    labelProps?: ComponentProps<typeof LabeledAutocomplete>['labelProps'];
-}
-
-type AutocompleteProps = ComponentProps<typeof LabeledAutocomplete>['autocompleteProps'];
 
 // Maps relation types to roadmap IDs
 type TermRoadmapGrouping = Record<RoadmapTermRelation, Set<string>>;
@@ -40,15 +32,16 @@ function getDefaultTermRoadmapGrouping(): TermRoadmapGrouping {
     };
 }
 
-export const SearchWithPlanner = ({ labelProps }: SearchWithPlannerProps) => {
+export const SearchWithPlanner = () => {
     const [termRoadmapGrouping, setTermRoadmapGrouping] = useState<TermRoadmapGrouping>(getDefaultTermRoadmapGrouping);
     const [isLoadingSearch, setIsLoadingSearch] = useState(false);
     const [openSignInDialog, setOpenSignInDialog] = useState(false);
+    const [menuAnchor, setMenuAnchor] = useState<null | HTMLElement>(null);
+    const menuOpen = Boolean(menuAnchor);
 
     const { sessionIsValid, hasCheckedAuth } = useSessionStore(
         useShallow((state) => ({
             sessionIsValid: state.sessionIsValid,
-
             hasCheckedAuth: state.hasCheckedAuth,
         }))
     );
@@ -85,100 +78,124 @@ export const SearchWithPlanner = ({ labelProps }: SearchWithPlannerProps) => {
         });
     }, [plannerRoadmaps, doesRoadmapIncludeTerm]);
 
-    const search = async (roadmapId: Roadmap['id']): Promise<boolean> => {
-        const roadmap = plannerRoadmaps.find((roadmap) => roadmap.id.toString() === roadmapId.toString());
-        if (!roadmap) {
-            openSnackbar('error', "Couldn't find selected roadmap!");
-            return false;
+    const closeMenu = () => setMenuAnchor(null);
+
+    const search = useCallback(
+        async (roadmapId: Roadmap['id']): Promise<boolean> => {
+            const roadmap = plannerRoadmaps.find((roadmap) => roadmap.id.toString() === roadmapId.toString());
+            if (!roadmap) {
+                openSnackbar('error', "Couldn't find selected roadmap!");
+                return false;
+            }
+
+            const term = RightPaneStore.getFormData().term;
+            const quarterPlan = getQuarterPlan(roadmap, term);
+            if (!quarterPlan) {
+                openSnackbar('error', `The provided roadmap does not contain ${term.shortName}`);
+                return false;
+            }
+            try {
+                setIsLoadingSearch(true);
+                const courseIds = quarterPlan.courses
+                    .filter((coursePlan) => !coursePlan.courseId.startsWith('CUSTOM#'))
+                    .map((coursePlan) => coursePlan.courseId);
+                const courses = await trpc.course.getMultiple.query({ courseIds });
+                const searchData = courses.map(({ department, courseNumber }) => ({
+                    deptValue: department,
+                    courseNumber,
+                }));
+
+                RightPaneStore.setMultiSearchData(searchData);
+                displaySections();
+            } catch (error) {
+                console.error('Something went wrong while searching with Planner:', error);
+                openSnackbar('error', 'Something went wrong while searching with Planner.');
+                return false;
+            } finally {
+                setIsLoadingSearch(false);
+            }
+            return true;
+        },
+        [plannerRoadmaps, displaySections]
+    );
+
+    const roadmapMenuItems = useMemo(() => {
+        if (plannerRoadmaps.length === 0) {
+            return null;
         }
-
-        const term = RightPaneStore.getFormData().term;
-        const quarterPlan = getQuarterPlan(roadmap, term);
-        if (!quarterPlan) {
-            openSnackbar('error', `The provided roadmap does not contain ${term.shortName}`);
-            return false;
-        }
-        try {
-            setIsLoadingSearch(true);
-            const courseIds = quarterPlan.courses
-                .filter((coursePlan) => !coursePlan.courseId.startsWith('CUSTOM#'))
-                .map((coursePlan) => coursePlan.courseId);
-            const courses = await trpc.course.getMultiple.query({ courseIds });
-            const searchData = courses.map(({ department, courseNumber }) => ({ deptValue: department, courseNumber }));
-
-            RightPaneStore.setMultiSearchData(searchData);
-            displaySections();
-        } catch (error) {
-            console.error('Something went wrong while searching with Planner:', error);
-            openSnackbar('error', 'Something went wrong while searching with Planner.');
-            return false;
-        } finally {
-            setIsLoadingSearch(false);
-        }
-        return true;
-    };
-
-    const groupBy = (option: Roadmap) => {
-        return doesRoadmapIncludeTerm(option.id) ? RoadmapTermRelation.IncludesTerm : RoadmapTermRelation.ExcludesTerm;
-    };
-
-    const renderGroup: AutocompleteProps['renderGroup'] = (params) => {
         const termShortName = RightPaneStore.getFormData().term.shortName;
-        const includesTerm = params.group === RoadmapTermRelation.IncludesTerm;
-        const keyword = includesTerm ? 'Includes' : "Doesn't Include";
+        const items: ReactNode[] = [];
+        let previousGroup: RoadmapTermRelation | undefined;
 
-        return (
-            <li key={params.key}>
-                <HorizontalRightDivider>
-                    <Typography>
-                        {keyword} {termShortName}
-                    </Typography>
-                </HorizontalRightDivider>
-                <ul style={{ padding: 0 }}>{params.children}</ul>
-            </li>
-        );
-    };
-
-    const renderOption = (props: HTMLAttributes<HTMLLIElement>, roadmap: Roadmap) => {
-        const menuItem = (
-            <Box
-                key={roadmap.id}
-                display="flex"
-                alignItems="center"
-                justifyContent="space-between"
-                sx={{ paddingRight: 1 }}
-            >
-                <MenuItem
-                    {...props}
-                    key={roadmap.id}
-                    onClick={() => search(roadmap.id)}
-                    disabled={!doesRoadmapIncludeTerm(roadmap.id)}
-                    sx={{ width: '100%' }}
-                >
-                    <Typography
-                        sx={{ marginLeft: 1, overflow: 'hidden', whiteSpace: 'nowrap', textOverflow: 'ellipsis' }}
-                        title={roadmap.name}
+        for (const roadmap of sortedRoadmaps) {
+            const group = doesRoadmapIncludeTerm(roadmap.id)
+                ? RoadmapTermRelation.IncludesTerm
+                : RoadmapTermRelation.ExcludesTerm;
+            if (group !== previousGroup) {
+                const keyword = group === RoadmapTermRelation.IncludesTerm ? 'Includes' : "Doesn't include";
+                items.push(
+                    <ListSubheader
+                        key={`roadmap-group-${group}-${termShortName}`}
+                        disableSticky
+                        sx={{ typography: 'caption', lineHeight: 2.25, color: 'text.secondary' }}
                     >
-                        {roadmap.name}
-                    </Typography>
-                </MenuItem>
+                        {keyword} {termShortName}
+                    </ListSubheader>
+                );
+                previousGroup = group;
+            }
 
-                <Tooltip title="Open Planner">
-                    <IconButton href={PLANNER_LINK} size="small" aria-label="Open Planner">
-                        <OpenInBrowser fontSize="small" />
-                    </IconButton>
-                </Tooltip>
-            </Box>
-        );
-        if (termRoadmapGrouping[RoadmapTermRelation.NoCourses].has(roadmap.id.toString())) {
-            return (
-                <Tooltip key={roadmap.id} title="This roadmap has no courses for this term">
-                    <span>{menuItem}</span>
-                </Tooltip>
+            const noCourses = termRoadmapGrouping[RoadmapTermRelation.NoCourses].has(roadmap.id.toString());
+            const disabled = !doesRoadmapIncludeTerm(roadmap.id);
+
+            const menuItem = (
+                <MenuItem
+                    key={roadmap.id}
+                    disabled={disabled}
+                    dense
+                    title={noCourses ? 'This roadmap has no courses for this term' : undefined}
+                    onClick={() => {
+                        if (disabled) {
+                            return;
+                        }
+                        closeMenu();
+                        void search(roadmap.id);
+                    }}
+                    sx={{ py: 0.5, pr: 0.5 }}
+                >
+                    <Box
+                        display="flex"
+                        alignItems="center"
+                        justifyContent="space-between"
+                        width="100%"
+                        gap={1}
+                        minWidth={0}
+                    >
+                        <Typography variant="body2" noWrap title={roadmap.name} sx={{ flex: '1 1 auto', minWidth: 0 }}>
+                            {roadmap.name}
+                        </Typography>
+                        <Tooltip title="Open Planner">
+                            <IconButton
+                                size="small"
+                                href={PLANNER_LINK}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                component="a"
+                                aria-label="Open Planner"
+                                onClick={(event) => event.stopPropagation()}
+                            >
+                                <OpenInBrowser fontSize="small" />
+                            </IconButton>
+                        </Tooltip>
+                    </Box>
+                </MenuItem>
             );
+
+            items.push(menuItem);
         }
-        return menuItem;
-    };
+
+        return items;
+    }, [plannerRoadmaps.length, sortedRoadmaps, termRoadmapGrouping, doesRoadmapIncludeTerm, search]);
 
     useEffect(() => {
         const updateTermRoadmaps = () => {
@@ -214,7 +231,7 @@ export const SearchWithPlanner = ({ labelProps }: SearchWithPlannerProps) => {
                 }
             })();
         }
-    }, [searchParams, plannerRoadmaps, hasSearchedWithUrlParams]);
+    }, [searchParams, plannerRoadmaps, hasSearchedWithUrlParams, search, setHasSearchedWithUrlParams]);
 
     useEffect(() => {
         if (hasCheckedAuth && !sessionIsValid && shouldSearchPlannerFromParams()) {
@@ -222,41 +239,56 @@ export const SearchWithPlanner = ({ labelProps }: SearchWithPlannerProps) => {
         }
     }, [sessionIsValid, hasCheckedAuth]);
 
-    const searchComponent = (
-        <LabeledAutocomplete
-            label="Roadmap"
-            disabled={!sessionIsValid || isLoadingSearch}
-            autocompleteProps={{
-                options: sortedRoadmaps,
-                getOptionLabel: (roadmap) => roadmap.name.toString(),
-                loading: isPlannerLoading,
-                loadingText: 'Loading Planner...',
-                noOptionsText: 'No roadmaps found',
-                groupBy: groupBy,
-                renderGroup: renderGroup,
-                renderOption: renderOption,
-                ...(plannerRoadmaps.length === 0 && {
-                    slotProps: { popper: { sx: { '& .MuiAutocomplete-noOptions': { padding: 0 } } } },
-                    noOptionsText: <CreateRoadmapLinkItem />,
-                }),
+    const handleRoadmapButtonClick = (event: MouseEvent<HTMLButtonElement>) => {
+        if (!sessionIsValid) {
+            setOpenSignInDialog(true);
+            return;
+        }
+        setMenuAnchor(event.currentTarget);
+    };
+
+    const roadmapButton = (
+        <Button
+            variant="outlined"
+            size="small"
+            color="secondary"
+            disabled={isLoadingSearch}
+            onClick={handleRoadmapButtonClick}
+            endIcon={<KeyboardArrowDown />}
+            aria-haspopup="true"
+            aria-expanded={menuOpen ? 'true' : undefined}
+            sx={{ flex: '1 1 0', minWidth: 'min(100%, 140px)', maxWidth: '100%' }}
+        >
+            {isLoadingSearch ? 'Loading…' : isPlannerLoading ? 'Roadmaps…' : 'Roadmap'}
+        </Button>
+    );
+
+    const menu = (
+        <Menu
+            anchorEl={menuAnchor}
+            open={menuOpen}
+            onClose={closeMenu}
+            slotProps={{
+                paper: {
+                    sx: { maxHeight: 360, minWidth: menuAnchor ? menuAnchor.clientWidth : undefined },
+                },
             }}
-            textFieldProps={{
-                placeholder: isLoadingSearch ? 'Loading...' : 'Select roadmap from Planner',
-                fullWidth: true,
-            }}
-            labelProps={labelProps}
-            loading={isLoadingSearch}
-            isAligned
-        />
+        >
+            {plannerRoadmaps.length === 0 ? (
+                <CreateRoadmapLinkItem verticalPadding="10px" value="" />
+            ) : (
+                roadmapMenuItems
+            )}
+        </Menu>
     );
 
     if (!sessionIsValid) {
         return (
             <>
                 <Tooltip title="Sign in to search with Planner">
-                    <span>{searchComponent}</span>
+                    <span>{roadmapButton}</span>
                 </Tooltip>
-
+                {menu}
                 <SignInDialog
                     open={openSignInDialog}
                     onClose={() => setOpenSignInDialog(false)}
@@ -266,5 +298,10 @@ export const SearchWithPlanner = ({ labelProps }: SearchWithPlannerProps) => {
         );
     }
 
-    return searchComponent;
+    return (
+        <>
+            {roadmapButton}
+            {menu}
+        </>
+    );
 };

--- a/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/constants.ts
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/constants.ts
@@ -1,3 +1,5 @@
+import type { SxProps, Theme } from '@mui/material/styles';
+
 export const BASIC_SEARCH_PARAMS = ['term'] as const;
 
 export type BasicSearchParam = (typeof BASIC_SEARCH_PARAMS)[number];
@@ -46,3 +48,23 @@ export const GE_LIST = [
 ] as const;
 
 export const ANY_GE = GE_LIST[0].value;
+
+/** Shared layout for quick-search shortcut pills (Roadmap, department, GE). */
+export const QUICK_SEARCH_SHORTCUT_PILL_SX: SxProps<Theme> = {
+    flex: '1 1 0',
+    minWidth: 0,
+    maxWidth: '100%',
+    borderRadius: 9999,
+    px: 1.25,
+    py: 0.5,
+    textTransform: 'none',
+    justifyContent: 'flex-start',
+    '& .MuiButton-label': {
+        display: 'flex',
+        alignItems: 'center',
+        width: '100%',
+        minWidth: 0,
+        gap: 0.5,
+    },
+    '& .MuiButton-startIcon': { marginRight: 0 },
+};

--- a/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/constants.ts
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/constants.ts
@@ -1,4 +1,5 @@
-import type { SxProps, Theme } from '@mui/material/styles';
+import type { Theme } from '@mui/material/styles';
+import type { SystemStyleObject } from '@mui/system';
 
 export const BASIC_SEARCH_PARAMS = ['term'] as const;
 
@@ -50,7 +51,7 @@ export const GE_LIST = [
 export const ANY_GE = GE_LIST[0].value;
 
 /** Shared layout for quick-search shortcut pills (Roadmap, department, GE). */
-export const QUICK_SEARCH_SHORTCUT_PILL_SX: SxProps<Theme> = {
+export const QUICK_SEARCH_SHORTCUT_PILL_SX: SystemStyleObject<Theme> = {
     flex: '1 1 0',
     minWidth: 0,
     maxWidth: '100%',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The Planner roadmap picker is no longer a second labeled field beside the fuzzy search box. It appears as a compact **Roadmap** pill with a dropdown directly under the main search input, alongside **COMPSCI** and **GE III (3)** shortcut pills.

All three shortcuts share **equal flex width**, **fully rounded** outlines, **leading icons** (`EventNote` for Planner/roadmap to match the app switcher, `Search` for COMPSCI, `School` for GE), and truncated labels where space is tight. The roadmap pill keeps the chevron on the **trailing** edge via `marginLeft: auto` on the end icon.

Roadmap behavior (grouping, loading courses, URL `importRoadmap` handling, sign-in prompts) is unchanged aside from presentation. COMPSCI and GE III run the same search flow as other quick department / GE selections.

**Deploy fix:** `QUICK_SEARCH_SHORTCUT_PILL_SX` is typed as `SystemStyleObject<Theme>` (not `SxProps`) and the roadmap button uses a single merged `sx` object so Next.js production typecheck accepts it (staging deploy was failing on `sx={[QUICK_SEARCH_SHORTCUT_PILL_SX, …]}`).

## Test Plan

- [ ] Open Quick Search: three pills span the row with equal width and pill-shaped borders.
- [ ] Signed in: open **Roadmap** menu and run a roadmap search; chevron stays on the right.
- [ ] Signed out: click **Roadmap** and confirm the sign-in dialog appears.
- [ ] **COMPSCI** and **GE III (3)** run the expected department / GE searches.
- [ ] Staging deploy / `next build` typecheck succeeds.

## Issues

Closes #

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5fb7c170-c548-46f7-8d4e-fb94bec080b3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5fb7c170-c548-46f7-8d4e-fb94bec080b3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

