### PR TITLE
fix: extract parseTermShortName helper for update-terms script

### DIFF
--- a/apps/antalmanac/scripts/update-terms.ts
+++ b/apps/antalmanac/scripts/update-terms.ts
@@ -6,7 +6,6 @@ import { createClient } from '@packages/anteater-api/client';
 import type { WebsocTerm } from '@packages/anteater-api/types';
 import { flattenSections } from '@packages/anteater-api/utils';
 
-import { getTermByShortName } from '../src/lib/term.js';
 import { DEPLOYED_TERMS_FILE } from './lib/paths.js';
 
 interface DeployedTermsData {
@@ -19,13 +18,7 @@ interface DeployedTermsData {
 const aapiClient = createClient({ apiKey: process.env.ANTEATER_API_KEY });
 
 async function getSectionCount(term: WebsocTerm) {
-    const aaTerm = getTermByShortName(term.shortName);
-
-    if (!aaTerm) {
-        throw new Error(`Unknown term: ${term.shortName}`);
-    }
-
-    const { year, quarter, shortName } = aaTerm;
+    const { year, quarter, shortName } = term;
     console.log(`Checking section count for ${shortName}...`);
     const response = await aapiClient.websoc.query({ year, quarter });
     return flattenSections(response).length;

--- a/apps/antalmanac/scripts/update-terms.ts
+++ b/apps/antalmanac/scripts/update-terms.ts
@@ -2,6 +2,7 @@ import 'dotenv/config';
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import { dirname } from 'node:path';
 
+import { QuarterSchema } from '@packages/antalmanac-types';
 import { createClient } from '@packages/anteater-api/client';
 import type { WebsocTerm } from '@packages/anteater-api/types';
 import { flattenSections } from '@packages/anteater-api/utils';
@@ -18,7 +19,9 @@ interface DeployedTermsData {
 const aapiClient = createClient({ apiKey: process.env.ANTEATER_API_KEY });
 
 async function getSectionCount(term: WebsocTerm) {
-    const { year, quarter, shortName } = term;
+    const { shortName } = term;
+    const [year, rawQuarter] = shortName.split(' ');
+    const quarter = QuarterSchema.parse(rawQuarter);
     console.log(`Checking section count for ${shortName}...`);
     const response = await aapiClient.websoc.query({ year, quarter });
     return flattenSections(response).length;

--- a/apps/antalmanac/scripts/update-terms.ts
+++ b/apps/antalmanac/scripts/update-terms.ts
@@ -2,11 +2,11 @@ import 'dotenv/config';
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import { dirname } from 'node:path';
 
-import { QuarterSchema } from '@packages/antalmanac-types';
 import { createClient } from '@packages/anteater-api/client';
 import type { WebsocTerm } from '@packages/anteater-api/types';
 import { flattenSections } from '@packages/anteater-api/utils';
 
+import { parseTermShortName } from '../src/lib/termHelpers.js';
 import { DEPLOYED_TERMS_FILE } from './lib/paths.js';
 
 interface DeployedTermsData {
@@ -20,8 +20,11 @@ const aapiClient = createClient({ apiKey: process.env.ANTEATER_API_KEY });
 
 async function getSectionCount(term: WebsocTerm) {
     const { shortName } = term;
-    const [year, rawQuarter] = shortName.split(' ');
-    const quarter = QuarterSchema.parse(rawQuarter);
+    const parsed = parseTermShortName(shortName);
+    if (!parsed) {
+        throw new Error(`Invalid term shortName from API: ${shortName}`);
+    }
+    const { year, quarter } = parsed;
     console.log(`Checking section count for ${shortName}...`);
     const response = await aapiClient.websoc.query({ year, quarter });
     return flattenSections(response).length;

--- a/apps/antalmanac/src/lib/term.ts
+++ b/apps/antalmanac/src/lib/term.ts
@@ -1,9 +1,11 @@
 import type { CourseEvent, CustomEvent } from '$components/Calendar/CourseCalendarEvent';
 import termJson from '$generated/termData.json';
-import { QuarterSchema, QUARTERS, type AATerm } from '@packages/antalmanac-types';
+import { QuarterSchema, type AATerm } from '@packages/antalmanac-types';
 import { Year } from '@packages/anteater-api/types';
 import { addWeeks, differenceInWeeks, setDay } from 'date-fns';
 import { z } from 'zod';
+
+import { parseTermShortName } from './termHelpers';
 
 export type { AATerm } from '@packages/antalmanac-types';
 
@@ -21,13 +23,11 @@ const termSchema = z
         year: z.string(),
         quarter: QuarterSchema,
         // TODO(zod-v4): Replace refine with z.literal.template() once we upgrade to Zod v4.
-        shortName: z.string().refine(
-            (s): s is AATerm['shortName'] => {
-                const parts = s.split(' ');
-                return parts.length === 2 && (QUARTERS as readonly string[]).includes(parts[1]);
-            },
-            { message: 'shortName must be "<year> <quarter>"' }
-        ),
+        shortName: z
+            .string()
+            .refine((s): s is AATerm['shortName'] => parseTermShortName(s) !== undefined, {
+                message: 'shortName must be "<year> <quarter>"',
+            }),
         longName: z.string(),
         instructionStart: z.string().date(),
         instructionEnd: z.string().date(),

--- a/apps/antalmanac/src/lib/term.ts
+++ b/apps/antalmanac/src/lib/term.ts
@@ -1,11 +1,10 @@
 import type { CourseEvent, CustomEvent } from '$components/Calendar/CourseCalendarEvent';
 import termJson from '$generated/termData.json';
+import { parseTermShortName } from '$lib/termHelpers';
 import { QuarterSchema, type AATerm } from '@packages/antalmanac-types';
 import { Year } from '@packages/anteater-api/types';
 import { addWeeks, differenceInWeeks, setDay } from 'date-fns';
 import { z } from 'zod';
-
-import { parseTermShortName } from './termHelpers';
 
 export type { AATerm } from '@packages/antalmanac-types';
 
@@ -23,11 +22,9 @@ const termSchema = z
         year: z.string(),
         quarter: QuarterSchema,
         // TODO(zod-v4): Replace refine with z.literal.template() once we upgrade to Zod v4.
-        shortName: z
-            .string()
-            .refine((s): s is AATerm['shortName'] => parseTermShortName(s) !== undefined, {
-                message: 'shortName must be "<year> <quarter>"',
-            }),
+        shortName: z.string().refine((s): s is AATerm['shortName'] => parseTermShortName(s) !== undefined, {
+            message: 'shortName must be "<year> <quarter>"',
+        }),
         longName: z.string(),
         instructionStart: z.string().date(),
         instructionEnd: z.string().date(),

--- a/apps/antalmanac/src/lib/termHelpers.ts
+++ b/apps/antalmanac/src/lib/termHelpers.ts
@@ -1,13 +1,17 @@
 import { QuarterSchema } from '@packages/antalmanac-types';
 import type { Quarter, Year } from '@packages/anteater-api/types';
 
-export type TermParts = { year: Year; quarter: Quarter };
-
-export function parseTermShortName(shortName: string): TermParts | undefined {
+export function parseTermShortName(shortName: string): { year: Year; quarter: Quarter } | undefined {
     const parts = shortName.split(' ');
-    if (parts.length !== 2) return undefined;
+    if (parts.length !== 2) {
+        return undefined;
+    }
+
     const [year, rawQuarter] = parts;
     const result = QuarterSchema.safeParse(rawQuarter);
-    if (!result.success) return undefined;
+    if (!result.success) {
+        return undefined;
+    }
+
     return { year, quarter: result.data };
 }

--- a/apps/antalmanac/src/lib/termHelpers.ts
+++ b/apps/antalmanac/src/lib/termHelpers.ts
@@ -3,13 +3,6 @@ import type { Quarter, Year } from '@packages/anteater-api/types';
 
 export type TermParts = { year: Year; quarter: Quarter };
 
-/**
- * Parse a `"<year> <quarter>"` shortName (e.g. `"2025 Fall"`) into its parts.
- * Returns `undefined` if the format or quarter value is invalid.
- *
- * Kept free of `termData.json` and `$`-alias imports so it can run under
- * tsx (e.g. in the `update-terms` script) without a path-alias resolver.
- */
 export function parseTermShortName(shortName: string): TermParts | undefined {
     const parts = shortName.split(' ');
     if (parts.length !== 2) return undefined;

--- a/apps/antalmanac/src/lib/termHelpers.ts
+++ b/apps/antalmanac/src/lib/termHelpers.ts
@@ -1,0 +1,20 @@
+import { QuarterSchema } from '@packages/antalmanac-types';
+import type { Quarter, Year } from '@packages/anteater-api/types';
+
+export type TermParts = { year: Year; quarter: Quarter };
+
+/**
+ * Parse a `"<year> <quarter>"` shortName (e.g. `"2025 Fall"`) into its parts.
+ * Returns `undefined` if the format or quarter value is invalid.
+ *
+ * Kept free of `termData.json` and `$`-alias imports so it can run under
+ * tsx (e.g. in the `update-terms` script) without a path-alias resolver.
+ */
+export function parseTermShortName(shortName: string): TermParts | undefined {
+    const parts = shortName.split(' ');
+    if (parts.length !== 2) return undefined;
+    const [year, rawQuarter] = parts;
+    const result = QuarterSchema.safeParse(rawQuarter);
+    if (!result.success) return undefined;
+    return { year, quarter: result.data };
+}


### PR DESCRIPTION
`update-terms.ts` is the failure point of the `check-new-quarter` github actions workflow to check for new quarters/section changes to rebuild the app.

`update-terms.ts` imported `getTermByShortName` from `src/lib/term.ts`, which in turn imports `$generated/termData.json` and `$components/...` via path aliases that tsx cannot resolve at runtime. WebsocTerm only carries `shortName`/`longName` (not year/quarter), so we parse those out of `shortName` instead.

Extracted into a new `src/lib/termHelpers.ts` so both `term.ts` (zod refine) and `update-terms.ts` share one `parseTermShortName` helper instead of duplicating `split(' ')` logic. Per review, follow-up PR can move more termData-independent helpers out of `term.ts`.

thanks ai
## Summary

- new `src/lib/termHelpers.ts` with `parseTermShortName(shortName) -> { year, quarter } | undefined`
- `term.ts` zod refine uses it
- `update-terms.ts` uses it (no more transitive `$generated`/`$components` imports)

## Test Plan

- [x] `tsc --noEmit` clean for `scripts/update-terms.ts`
- [x] staging deploy goes green

## Issues

Closes #
