### PR TITLE
Define WebSoc runtime enums in packages/types (GE dedupe)

### DIFF
--- a/apps/antalmanac/src/components/RightPane/CoursePane/CourseRenderPane.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/CourseRenderPane.tsx
@@ -379,7 +379,7 @@ export default function CourseRenderPane(props: { id?: number }) {
             fullCourses: searchData.coursesFull,
             building: searchData.building,
             room: searchData.room,
-            division: searchData.division,
+            division: searchData.division === '' ? undefined : searchData.division,
             excludeRestrictionCodes: searchData.excludeRestrictionCodes.split('').join(','),
             days: searchData.days.split(/(?=[A-Z])/).join(','),
         }),

--- a/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/constants.ts
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/constants.ts
@@ -1,3 +1,5 @@
+import type { WebsocGe } from '@packages/antalmanac-types';
+
 export const BASIC_SEARCH_PARAMS = ['term'] as const;
 
 export type BasicSearchParam = (typeof BASIC_SEARCH_PARAMS)[number];
@@ -43,6 +45,6 @@ export const GE_LIST = [
     { value: 'GE-6', label: 'GE VI (6): Language other than English', shortLabel: 'GE VI (6)' },
     { value: 'GE-7', label: 'GE VII (7): Multicultural Studies', shortLabel: 'GE VII (7)' },
     { value: 'GE-8', label: 'GE VIII (8): International/Global Issues', shortLabel: 'GE VIII (8)' },
-] as const;
+] as const satisfies readonly { value: WebsocGe; label: string; shortLabel: string }[];
 
 export const ANY_GE = GE_LIST[0].value;

--- a/apps/antalmanac/src/components/RightPane/RightPaneStore.ts
+++ b/apps/antalmanac/src/components/RightPane/RightPaneStore.ts
@@ -4,9 +4,15 @@ import { AdvancedSearchParam, ManualSearchParam } from '$components/RightPane/Co
 import { normalizeGeSelection } from '$lib/multiGeSearch';
 import { getDefaultTerm, getTermByShortName } from '$lib/term';
 import { openSnackbar } from '$stores/SnackbarStore';
-import type { AATerm } from '@packages/antalmanac-types';
+import type { AATerm, WebsocFullCourses, WebsocDivision } from '@packages/antalmanac-types';
+import { WebsocDivisionSchema, WebsocFullCoursesSchema } from '@packages/antalmanac-types';
 
-const defaultAdvancedSearchValues: Record<AdvancedSearchParam, string> = {
+export type CourseDivisionFormValue = '' | Exclude<WebsocDivision, 'ANY'>;
+
+const defaultAdvancedSearchValues: Omit<Record<AdvancedSearchParam, string>, 'coursesFull' | 'division'> & {
+    coursesFull: WebsocFullCourses;
+    division: CourseDivisionFormValue;
+} = {
     instructor: '',
     units: '',
     endTime: '',
@@ -20,9 +26,12 @@ const defaultAdvancedSearchValues: Record<AdvancedSearchParam, string> = {
     days: '',
 };
 
-export interface CourseSearchParams extends Record<Exclude<ManualSearchParam, 'term'>, string> {
+export type CourseSearchParams = {
     term: AATerm;
-}
+} & Omit<Record<Exclude<ManualSearchParam, 'term'>, string>, 'coursesFull' | 'division'> & {
+        coursesFull: WebsocFullCourses;
+        division: CourseDivisionFormValue;
+    };
 
 type SearchParamKey = Exclude<keyof CourseSearchParams, 'term'>;
 
@@ -113,9 +122,28 @@ class RightPaneStore extends EventEmitter {
         const stringFields = Object.keys(defaultFormValues).filter((k): k is SearchParamKey => k !== 'term');
         for (const field of stringFields) {
             const paramValue = search.get(field) || search.get(field.toUpperCase());
-            if (paramValue !== null) {
-                this.formData[field] = field === 'ge' ? normalizeGeSelection(paramValue) : paramValue;
+            if (paramValue === null) continue;
+
+            if (field === 'ge') {
+                this.formData.ge = normalizeGeSelection(paramValue);
+                continue;
             }
+            if (field === 'coursesFull') {
+                const parsed = WebsocFullCoursesSchema.safeParse(paramValue);
+                this.formData.coursesFull = parsed.success ? parsed.data : defaultAdvancedSearchValues.coursesFull;
+                continue;
+            }
+            if (field === 'division') {
+                if (paramValue === '') {
+                    this.formData.division = '';
+                    continue;
+                }
+                const parsed = WebsocDivisionSchema.safeParse(paramValue);
+                this.formData.division = !parsed.success || parsed.data === 'ANY' ? '' : parsed.data;
+                continue;
+            }
+
+            this.formData[field] = paramValue;
         }
 
         this.emit('formDataChange');
@@ -140,7 +168,19 @@ class RightPaneStore extends EventEmitter {
     getWarningMessages = () => this.warningMessages;
 
     updateFormValue = (field: SearchParamKey, value: string) => {
-        this.formData[field] = value;
+        if (field === 'coursesFull') {
+            const parsed = WebsocFullCoursesSchema.safeParse(value);
+            this.formData.coursesFull = parsed.success ? parsed.data : 'ANY';
+        } else if (field === 'division') {
+            if (value === '') {
+                this.formData.division = '';
+            } else {
+                const parsed = WebsocDivisionSchema.safeParse(value);
+                this.formData.division = !parsed.success || parsed.data === 'ANY' ? '' : parsed.data;
+            }
+        } else {
+            this.formData[field] = value;
+        }
         this.emit('formDataChange');
     };
 

--- a/apps/antalmanac/src/components/RightPane/SectionTable/GEDataFetchProvider.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/GEDataFetchProvider.tsx
@@ -28,7 +28,7 @@ const GeDataFetchProvider = (props: SectionTableProps) => {
             fullCourses: formData.coursesFull,
             building: formData.building,
             room: formData.room,
-            division: formData.division,
+            division: formData.division === '' ? undefined : formData.division,
             excludeRestrictionCodes: formData.excludeRestrictionCodes.split('').join(','),
             days: formData.days.split(/(?=[A-Z])/).join(','),
         };

--- a/apps/antalmanac/src/lib/multiGeSearch.ts
+++ b/apps/antalmanac/src/lib/multiGeSearch.ts
@@ -1,8 +1,8 @@
 import { ANY_GE, GE_LIST } from '$components/RightPane/CoursePane/SearchForm/constants';
 import trpc from '$lib/api/trpc';
-import type { WebsocSearchInput } from '@packages/antalmanac-types';
+import type { WebsocSearchInput, WebsocGe } from '@packages/antalmanac-types';
 import { AACourse } from '@packages/antalmanac-types';
-import { GE, WebsocAPIResponse, WebsocDepartment, WebsocSchool } from '@packages/anteater-api/types';
+import { WebsocAPIResponse, WebsocDepartment, WebsocSchool } from '@packages/anteater-api/types';
 
 const VALID_GES: Set<string> = new Set(GE_LIST.map((option) => option.value).filter((value) => value !== ANY_GE));
 
@@ -24,8 +24,8 @@ export const normalizeGeSelection = (ge: string) => {
 };
 export const isMultiGeSelection = (ge: string) => parseSelectedGEs(ge).length > 1;
 
-export const gradesGeForManualSearch = (ge: string): GE =>
-    ge !== ANY_GE && !ge.includes(',') ? (ge as GE) : (ANY_GE as GE);
+export const gradesGeForManualSearch = (ge: string): WebsocGe =>
+    ge !== ANY_GE && !ge.includes(',') ? (ge as WebsocGe) : (ANY_GE as WebsocGe);
 
 const getCourseKeys = (response: WebsocAPIResponse) =>
     new Set(

--- a/packages/types/src/grades.ts
+++ b/packages/types/src/grades.ts
@@ -1,16 +1,4 @@
-import type { GE } from '@packages/anteater-api/types';
-import { z } from 'zod';
+import { WebsocGeSchema } from './websoc';
 
-export const GradesGeSchema = z.enum([
-    'GE-1A',
-    'GE-1B',
-    'GE-2',
-    'GE-3',
-    'GE-4',
-    'GE-5A',
-    'GE-5B',
-    'GE-6',
-    'GE-7',
-    'GE-8',
-    'ANY',
-] as const satisfies readonly GE[]);
+/** Same values as WebSoc `ge`; use {@link WebsocGeSchema} for new code. */
+export const GradesGeSchema = WebsocGeSchema;

--- a/packages/types/src/websoc.ts
+++ b/packages/types/src/websoc.ts
@@ -1,13 +1,67 @@
 import type {
-    WebsocSection,
+    GE,
     WebsocCourse,
-    WebsocQueryParams,
+    WebsocSection,
     WebsocSectionStatus,
     WebsocSectionType,
 } from '@packages/anteater-api/types';
 import { z } from 'zod';
 
 import { QuarterSchema } from './calendar';
+
+/** WebSoc `ge` query values; identical to the grades API `ge` parameter (see `GradesGeSchema`). */
+export const WEBSOC_GE_VALUES = [
+    'ANY',
+    'GE-1A',
+    'GE-1B',
+    'GE-2',
+    'GE-3',
+    'GE-4',
+    'GE-5A',
+    'GE-5B',
+    'GE-6',
+    'GE-7',
+    'GE-8',
+] as const satisfies readonly GE[];
+
+export type WebsocGe = (typeof WEBSOC_GE_VALUES)[number];
+
+export const WebsocGeSchema = z.enum(WEBSOC_GE_VALUES);
+
+const WEBSOC_GE_SET = new Set<string>(WEBSOC_GE_VALUES);
+
+/**
+ * Single WebSoc/grades `ge` token, or a comma-separated list of tokens (manual search multi-GE).
+ * Each segment must be a {@link WEBSOC_GE_VALUES} member after trimming.
+ */
+export const WebsocGeSearchParamSchema = z.string().refine(
+    (val) => {
+        const parts = val
+            .split(',')
+            .map((p) => p.trim())
+            .filter(Boolean);
+        return parts.length > 0 && parts.every((p) => WEBSOC_GE_SET.has(p));
+    },
+    { message: 'Invalid GE value' }
+);
+
+export const WEBSOC_DIVISION_VALUES = ['LowerDiv', 'UpperDiv', 'Graduate', 'ANY'] as const;
+
+export type WebsocDivision = (typeof WEBSOC_DIVISION_VALUES)[number];
+
+export const WebsocDivisionSchema = z.enum(WEBSOC_DIVISION_VALUES);
+
+export const WEBSOC_FULL_COURSES_VALUES = ['ANY', 'SkipFull', 'SkipFullWaitlist', 'FullOnly', 'Overenrolled'] as const;
+
+export type WebsocFullCourses = (typeof WEBSOC_FULL_COURSES_VALUES)[number];
+
+export const WebsocFullCoursesSchema = z.enum(WEBSOC_FULL_COURSES_VALUES);
+
+export const WEBSOC_CANCELLED_COURSES_VALUES = ['Exclude', 'Include', 'Only'] as const;
+
+export type WebsocCancelledCourses = (typeof WEBSOC_CANCELLED_COURSES_VALUES)[number];
+
+export const WebsocCancelledCoursesSchema = z.enum(WEBSOC_CANCELLED_COURSES_VALUES);
 
 export const WebsocSectionTypeSchema = z.enum([
     'Act',
@@ -23,6 +77,15 @@ export const WebsocSectionTypeSchema = z.enum([
     'Tap',
     'Tut',
 ] as const satisfies readonly WebsocSectionType[]);
+
+export const WebsocSectionTypeFilterSchema = z.union([z.literal('ANY'), WebsocSectionTypeSchema]);
+
+export type WebsocSectionTypeFilter = z.infer<typeof WebsocSectionTypeFilterSchema>;
+
+/** WebSoc `units` query: literal `VAR` or a free-form units string per OpenAPI. */
+export const WebsocUnitsFilterSchema = z.union([z.literal('VAR'), z.string()]);
+
+export type WebsocUnitsFilter = z.infer<typeof WebsocUnitsFilterSchema>;
 
 export const WebsocSectionStatusSchema = z.enum([
     '',
@@ -45,11 +108,23 @@ type AACourseExtendedProperties = {
 
 export type AACourse = Omit<WebsocCourse, 'sections'> & AACourseExtendedProperties;
 
+const emptyStringToUndefined = <T extends z.ZodTypeAny>(schema: T) =>
+    z.preprocess((v) => (v === '' ? undefined : v), schema.optional());
+
+const WEBSOC_DIVISION_SET = new Set<string>(WEBSOC_DIVISION_VALUES);
+
+/** Accepts WebSoc division values or `''` (form “any”); unknown strings are dropped. */
+export const WebsocDivisionSearchParamSchema = z.preprocess((v) => {
+    if (v === '' || v === null || v === undefined) return undefined;
+    if (typeof v === 'string' && WEBSOC_DIVISION_SET.has(v)) return v;
+    return undefined;
+}, WebsocDivisionSchema.optional());
+
 export const WebsocSearchInputSchema = z.object({
     year: z.string(),
     quarter: QuarterSchema,
     department: z.string().optional(),
-    ge: z.string().optional(),
+    ge: WebsocGeSearchParamSchema.optional(),
     courseNumber: z.string().optional(),
     courseTitle: z.string().optional(),
     sectionCodes: z.string().optional(),
@@ -57,19 +132,15 @@ export const WebsocSearchInputSchema = z.object({
     days: z.string().optional(),
     building: z.string().optional(),
     room: z.string().optional(),
-    division: z.string().optional(),
-    sectionType: z.string().optional(),
-    fullCourses: z.string().optional(),
-    cancelledCourses: z.string().optional(),
-    units: z.string().optional(),
+    division: WebsocDivisionSearchParamSchema,
+    sectionType: emptyStringToUndefined(WebsocSectionTypeFilterSchema),
+    fullCourses: WebsocFullCoursesSchema.optional(),
+    cancelledCourses: emptyStringToUndefined(WebsocCancelledCoursesSchema),
+    units: emptyStringToUndefined(WebsocUnitsFilterSchema),
     startTime: z.string().optional(),
     endTime: z.string().optional(),
     excludeRestrictionCodes: z.string().optional(),
     includeRelatedCourses: z.string().nullable().optional(),
-}) satisfies z.ZodType<{
-    [K in keyof WebsocQueryParams]: NonNullable<WebsocQueryParams[K]> extends string
-        ? string | WebsocQueryParams[K]
-        : WebsocQueryParams[K];
-}>;
+});
 
 export type WebsocSearchInput = z.infer<typeof WebsocSearchInputSchema>;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Centralize WebSoc-related query enums and Zod schemas in `packages/types/src/websoc.ts`, including GE values shared with the grades API. `GradesGeSchema` now re-exports `WebsocGeSchema` so GE literals are not duplicated. Added `WebsocGeSearchParamSchema` for comma-separated multi-GE strings used in manual search.

Tightened `WebsocSearchInputSchema` for division, section type filter, full/waitlist behaviour, cancelled courses, and units (with preprocess helpers for empty form strings and permissive division parsing). Dropped the previous `satisfies` tie to `WebsocQueryParams` because `z.preprocess` widens input types in a way TypeScript cannot reconcile with that constraint.

Updated `CourseSearchParams` (`coursesFull`, `division`), `RightPaneStore` URL/form handling, `CourseRenderPane` / `GEDataFetchProvider` query construction, `GE_LIST` typing, and `gradesGeForManualSearch` to align with the new types.

## Test Plan

- [ ] `pnpm exec tsc --noEmit` in `packages/types`
- [ ] Manual search: GE single, multi-GE, and ANY; course level empty vs each option; class full option
- [ ] Section table GE fetch path still loads related sections

## Issues

Related to tighter WebSoc typing work (e.g. #1789).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-770c05cd-257c-42f9-8b66-26ee40f188bc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-770c05cd-257c-42f9-8b66-26ee40f188bc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

