### PR TITLE
fix(calendar): empty state from schedule state; finals view support

### DIFF
--- a/apps/antalmanac/src/actions/AppStoreActions.ts
+++ b/apps/antalmanac/src/actions/AppStoreActions.ts
@@ -3,6 +3,7 @@ import trpc from '$lib/api/trpc';
 import { warnMultipleTerms } from '$lib/helpers';
 import { setLocalStorageUserId, setLocalStorageDataCache } from '$lib/localStorage';
 import { isNativeIosApp, NATIVE_IOS_REDIRECT_URI } from '$lib/platform';
+import { isScheduleContentEmpty } from '$lib/scheduleContentEmpty';
 import { getErrorMessage } from '$lib/utils';
 import AppStore from '$stores/AppStore';
 import { deleteTempSaveData } from '$stores/localTempSaveDataHelpers';
@@ -65,21 +66,13 @@ export const addCourse = (
 };
 
 export function isEmptySchedule(schedules: ShortCourseSchedule[]) {
-    for (const schedule of schedules) {
-        if (schedule.courses.length > 0) {
-            return false;
-        }
-
-        if (schedule.customEvents.length > 0) {
-            return false;
-        }
-
-        if (schedule.scheduleNote !== '') {
-            return false;
-        }
-    }
-
-    return true;
+    return schedules.every((schedule) =>
+        isScheduleContentEmpty({
+            courses: schedule.courses,
+            customEvents: schedule.customEvents,
+            scheduleNote: schedule.scheduleNote ?? '',
+        })
+    );
 }
 
 export const saveSchedule = async ({ postHog }: { postHog?: PostHog }) => {

--- a/apps/antalmanac/src/components/Calendar/CalendarRoot.tsx
+++ b/apps/antalmanac/src/components/Calendar/CalendarRoot.tsx
@@ -101,7 +101,9 @@ function createSkeletonEvents(): SkeletonEvent[] {
 
 export const ScheduleCalendar = memo(() => {
     const [showFinalsSchedule, setShowFinalsSchedule] = useState(false);
-    const [currentScheduleCourses, setCurrentScheduleCourses] = useState(() => AppStore.schedule.getCurrentCourses());
+    const [currentScheduleIsEmpty, setCurrentScheduleIsEmpty] = useState(() =>
+        AppStore.schedule.isCurrentScheduleEmpty()
+    );
     const [eventsInCalendar, setEventsInCalendar] = useState(() => AppStore.getEventsInCalendar());
     const [finalsEventsInCalendar, setFinalEventsInCalendar] = useState(() => AppStore.getFinalEventsInCalendar());
     const [currentScheduleIndex, setCurrentScheduleIndex] = useState(() => AppStore.getCurrentScheduleIndex());
@@ -240,12 +242,8 @@ export const ScheduleCalendar = memo(() => {
     };
 
     const showEmptyState = useMemo(
-        () =>
-            !loadingSchedule &&
-            !showFinalsSchedule &&
-            !hoveredCalendarizedCourses &&
-            currentScheduleCourses.length === 0,
-        [loadingSchedule, showFinalsSchedule, hoveredCalendarizedCourses, currentScheduleCourses.length]
+        () => !loadingSchedule && !hoveredCalendarizedCourses && !hoveredCalendarizedFinal && currentScheduleIsEmpty,
+        [loadingSchedule, hoveredCalendarizedCourses, hoveredCalendarizedFinal, currentScheduleIsEmpty]
     );
 
     const hasWeekendCourse = events.some((event) => event.start.getDay() === 0 || event.start.getDay() === 6);
@@ -296,7 +294,7 @@ export const ScheduleCalendar = memo(() => {
             setCurrentScheduleIndex(AppStore.getCurrentScheduleIndex());
             setEventsInCalendar(AppStore.getEventsInCalendar());
             setFinalEventsInCalendar(AppStore.getFinalEventsInCalendar());
-            setCurrentScheduleCourses(AppStore.schedule.getCurrentCourses());
+            setCurrentScheduleIsEmpty(AppStore.schedule.isCurrentScheduleEmpty());
         };
 
         const updateScheduleNames = () => {
@@ -307,6 +305,7 @@ export const ScheduleCalendar = memo(() => {
         AppStore.on('customEventsChange', updateEventsInCalendar);
         AppStore.on('colorChange', updateEventsInCalendar);
         AppStore.on('currentScheduleIndexChange', updateEventsInCalendar);
+        AppStore.on('scheduleNotesChange', updateEventsInCalendar);
         AppStore.on('scheduleNamesChange', updateScheduleNames);
 
         return () => {
@@ -314,6 +313,7 @@ export const ScheduleCalendar = memo(() => {
             AppStore.off('customEventsChange', updateEventsInCalendar);
             AppStore.off('colorChange', updateEventsInCalendar);
             AppStore.off('currentScheduleIndexChange', updateEventsInCalendar);
+            AppStore.off('scheduleNotesChange', updateEventsInCalendar);
             AppStore.off('scheduleNamesChange', updateScheduleNames);
         };
     }, []);

--- a/apps/antalmanac/src/lib/scheduleContentEmpty.ts
+++ b/apps/antalmanac/src/lib/scheduleContentEmpty.ts
@@ -1,0 +1,11 @@
+/**
+ * True when a schedule slice has nothing the user added (courses, custom events, or a note).
+ * Matches the per-schedule checks used for save/import empty detection.
+ */
+export function isScheduleContentEmpty(schedule: {
+    courses: { readonly length: number };
+    customEvents: { readonly length: number };
+    scheduleNote: string;
+}): boolean {
+    return schedule.courses.length === 0 && schedule.customEvents.length === 0 && schedule.scheduleNote === '';
+}

--- a/apps/antalmanac/src/stores/Schedules.ts
+++ b/apps/antalmanac/src/stores/Schedules.ts
@@ -1,9 +1,10 @@
 import trpc from '$lib/api/trpc';
+import { isScheduleContentEmpty } from '$lib/scheduleContentEmpty';
 import { getDefaultTerm, getTermByShortName } from '$lib/term';
-import { getColorForNewSection, getCourseId, groupCourseSections } from '$stores/scheduleHelpers';
-import type { AATerm } from '@packages/antalmanac-types';
 import { moveArrayElements } from '$lib/utils';
+import { getColorForNewSection, getCourseId, groupCourseSections } from '$stores/scheduleHelpers';
 import { openSnackbar } from '$stores/SnackbarStore';
+import type { AATerm } from '@packages/antalmanac-types';
 import type {
     Schedule,
     ScheduleCourse,
@@ -373,6 +374,19 @@ export class Schedules {
 
     getCurrentCustomEvents() {
         return this.schedules[this.currentScheduleIndex]?.customEvents || [];
+    }
+
+    /**
+     * Whether the active schedule has no courses, custom events, or note.
+     * Calendar empty state uses this (not calendarized events) so TBA meetings or
+     * non-scheduled finals do not look like an empty schedule.
+     */
+    isCurrentScheduleEmpty(): boolean {
+        return isScheduleContentEmpty({
+            courses: this.getCurrentCourses(),
+            customEvents: this.getCurrentCustomEvents(),
+            scheduleNote: this.getCurrentScheduleNote(),
+        });
     }
 
     /**

--- a/apps/antalmanac/tests/schedule-content-empty.test.ts
+++ b/apps/antalmanac/tests/schedule-content-empty.test.ts
@@ -1,0 +1,32 @@
+import { isScheduleContentEmpty } from '$lib/scheduleContentEmpty';
+import { describe, expect, it } from 'vitest';
+
+describe('isScheduleContentEmpty', () => {
+    it('is true only when there are no courses, custom events, or note', () => {
+        expect(isScheduleContentEmpty({ courses: [], customEvents: [], scheduleNote: '' })).toBe(true);
+
+        expect(
+            isScheduleContentEmpty({
+                courses: [{ x: 1 } as never],
+                customEvents: [],
+                scheduleNote: '',
+            })
+        ).toBe(false);
+
+        expect(
+            isScheduleContentEmpty({
+                courses: [],
+                customEvents: [{ y: 1 } as never],
+                scheduleNote: '',
+            })
+        ).toBe(false);
+
+        expect(
+            isScheduleContentEmpty({
+                courses: [],
+                customEvents: [],
+                scheduleNote: 'hello',
+            })
+        ).toBe(false);
+    });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The calendar empty overlay now keys off the same definition of an empty schedule used elsewhere (courses, custom events, and schedule note), via a shared `isScheduleContentEmpty` helper and `Schedules.isCurrentScheduleEmpty()`. This avoids tying the UI to calendarized events (so TBA-only meetings or courses without a scheduled final do not imply an empty schedule) and fixes custom-events-only schedules incorrectly showing the overlay.

The overlay is shown in finals mode when the schedule slice is still empty, and it is hidden while a finals hover preview is active (parallel to the weekly hover behavior).

`isEmptySchedule` in `AppStoreActions` now delegates to the shared helper to keep save/import checks aligned.

## Test Plan

- `pnpm lint`
- `pnpm test run apps/antalmanac/tests/schedule-content-empty.test.ts` (full `pnpm test run` fails in this environment without `src/generated/termData.json` for unrelated suites)

## Issues

N/A

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-adef5794-f248-4bb0-98dc-47daf46ade08"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-adef5794-f248-4bb0-98dc-47daf46ade08"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

