### PR TITLE
fix: calendar empty state to read from schedule state

### DIFF
--- a/apps/antalmanac/src/components/Calendar/CalendarRoot.tsx
+++ b/apps/antalmanac/src/components/Calendar/CalendarRoot.tsx
@@ -345,47 +345,43 @@ export const ScheduleCalendar = memo(() => {
                     backgroundColor: 'rgba(0, 0, 0, 0.1)',
                     zIndex: theme.zIndex.drawer + 1,
                     position: 'absolute',
-                    padding: ' 0',
+                    padding: 0,
                 })}
                 open={loadingSchedule}
             />
+
             <CalendarToolbar
                 currentScheduleIndex={currentScheduleIndex}
                 toggleDisplayFinalsSchedule={toggleDisplayFinalsSchedule}
                 showFinalsSchedule={showFinalsSchedule}
                 scheduleNames={scheduleNames}
             />
+
             <Box id="screenshot" height="0" flexGrow={1} position="relative">
                 <TbaCalendarCard />
                 <CalendarEventPopover />
 
-                {showEmptyState && (
-                    <Box
-                        data-html2canvas-ignore
-                        position="absolute"
-                        top={0}
-                        left={0}
-                        right={0}
-                        bottom={0}
-                        display="flex"
-                        alignItems="center"
-                        justifyContent="center"
-                        zIndex={1}
-                        sx={{
-                            backgroundColor: isDark ? 'rgba(18, 18, 18, 0.75)' : 'rgba(255, 255, 255, 0.7)',
+                <Backdrop
+                    open={showEmptyState}
+                    data-html2canvas-ignore
+                    sx={(theme) => ({
+                        color: '#ffff',
+                        backgroundColor: 'rgba(0, 0, 0, 0.1)',
+                        zIndex: theme.zIndex.drawer + 1,
+                        position: 'absolute',
+                        padding: 0,
+                    })}
+                >
+                    <EmptyState
+                        Icon={CalendarMonth}
+                        title="Your schedule is empty"
+                        description="Search for courses to start building your schedule."
+                        primaryAction={{
+                            label: 'Search for Courses',
+                            onClick: () => useTabStore.getState().setActiveTab('search'),
                         }}
-                    >
-                        <EmptyState
-                            Icon={CalendarMonth}
-                            title="Your schedule is empty"
-                            description="Search for courses to start building your schedule."
-                            primaryAction={{
-                                label: 'Search for Courses',
-                                onClick: () => useTabStore.getState().setActiveTab('search'),
-                            }}
-                        />
-                    </Box>
-                )}
+                    />
+                </Backdrop>
 
                 <Calendar<CalendarEvent, object>
                     key={`${culture}-${calendarView}`}

--- a/apps/antalmanac/src/components/Calendar/CalendarRoot.tsx
+++ b/apps/antalmanac/src/components/Calendar/CalendarRoot.tsx
@@ -102,6 +102,9 @@ function createSkeletonEvents(): SkeletonEvent[] {
 export const ScheduleCalendar = memo(() => {
     const [showFinalsSchedule, setShowFinalsSchedule] = useState(false);
     const [currentScheduleCourses, setCurrentScheduleCourses] = useState(() => AppStore.schedule.getCurrentCourses());
+    const [currentScheduleCustomEvents, setCurrentScheduleCustomEvents] = useState(() =>
+        AppStore.schedule.getCurrentCustomEvents()
+    );
     const [eventsInCalendar, setEventsInCalendar] = useState(() => AppStore.getEventsInCalendar());
     const [finalsEventsInCalendar, setFinalEventsInCalendar] = useState(() => AppStore.getFinalEventsInCalendar());
     const [currentScheduleIndex, setCurrentScheduleIndex] = useState(() => AppStore.getCurrentScheduleIndex());
@@ -242,10 +245,10 @@ export const ScheduleCalendar = memo(() => {
     const showEmptyState = useMemo(
         () =>
             !loadingSchedule &&
-            !showFinalsSchedule &&
             !hoveredCalendarizedCourses &&
-            currentScheduleCourses.length === 0,
-        [loadingSchedule, showFinalsSchedule, hoveredCalendarizedCourses, currentScheduleCourses.length]
+            currentScheduleCourses.length === 0 &&
+            currentScheduleCustomEvents.length === 0,
+        [loadingSchedule, hoveredCalendarizedCourses, currentScheduleCourses.length, currentScheduleCustomEvents.length]
     );
 
     const hasWeekendCourse = events.some((event) => event.start.getDay() === 0 || event.start.getDay() === 6);
@@ -297,6 +300,7 @@ export const ScheduleCalendar = memo(() => {
             setEventsInCalendar(AppStore.getEventsInCalendar());
             setFinalEventsInCalendar(AppStore.getFinalEventsInCalendar());
             setCurrentScheduleCourses(AppStore.schedule.getCurrentCourses());
+            setCurrentScheduleCustomEvents(AppStore.schedule.getCurrentCustomEvents());
         };
 
         const updateScheduleNames = () => {

--- a/apps/antalmanac/src/components/Calendar/CalendarRoot.tsx
+++ b/apps/antalmanac/src/components/Calendar/CalendarRoot.tsx
@@ -246,9 +246,16 @@ export const ScheduleCalendar = memo(() => {
         () =>
             !loadingSchedule &&
             !hoveredCalendarizedCourses &&
+            !hoveredCalendarizedFinal &&
             currentScheduleCourses.length === 0 &&
             currentScheduleCustomEvents.length === 0,
-        [loadingSchedule, hoveredCalendarizedCourses, currentScheduleCourses.length, currentScheduleCustomEvents.length]
+        [
+            loadingSchedule,
+            hoveredCalendarizedCourses,
+            hoveredCalendarizedFinal,
+            currentScheduleCourses.length,
+            currentScheduleCustomEvents.length,
+        ]
     );
 
     const hasWeekendCourse = events.some((event) => event.start.getDay() === 0 || event.start.getDay() === 6);

--- a/apps/antalmanac/src/components/Calendar/TbaCalendarCard.tsx
+++ b/apps/antalmanac/src/components/Calendar/TbaCalendarCard.tsx
@@ -146,16 +146,12 @@ export function TbaCalendarCard() {
         };
 
         AppStore.on('addedCoursesChange', updateTbaSections);
-        AppStore.on('removedCoursesChange', updateTbaSections);
-        AppStore.on('clearSchedule', updateTbaSections);
         AppStore.on('currentScheduleIndexChange', updateTbaSections);
 
         updateTbaSections();
 
         return () => {
             AppStore.off('addedCoursesChange', updateTbaSections);
-            AppStore.off('removedCoursesChange', updateTbaSections);
-            AppStore.off('clearSchedule', updateTbaSections);
             AppStore.off('currentScheduleIndexChange', updateTbaSections);
         };
     }, []);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes several bugs in the calendar empty-state logic in `CalendarRoot` and `TbaCalendarCard`.

**`CalendarRoot` — `showEmptyState` condition**

1. **Read from full schedule state, not just courses.** The emptiness check previously used only `currentScheduleCourses.length === 0`, ignoring custom events. A schedule containing only custom events (no courses) would falsely show "Your schedule is empty" even though events were visible on the calendar. The fix adds a `currentScheduleCustomEvents` state variable (mirroring how courses are already tracked) and requires both arrays to be empty before the overlay is shown.

2. **Show empty state in the finals view.** The condition included `!showFinalsSchedule`, which unconditionally suppressed the overlay when viewing the finals schedule — even on a completely empty schedule. That guard is removed so a truly empty schedule shows the empty-state card regardless of which view is active.

3. **Sync custom events in `updateEventsInCalendar`.** The shared update handler now also calls `setCurrentScheduleCustomEvents` so the new state stays consistent with courses, calendar events, and finals events on every `AppStore` change.

**`TbaCalendarCard` — dead event listeners**

`AppStore` never emits `removedCoursesChange` or `clearSchedule`. Both deletions and clears are already covered by the `addedCoursesChange` event that TbaCalendarCard already listens to. The two dead `.on`/`.off` pairs are removed.

## Test Plan

- Add only custom events (no courses) → empty state should **not** appear.
- Add only TBA courses (all meetings are TBA) → empty state should **not** appear.
- Add courses that only have scheduled finals (no regular meetings) → empty state should **not** appear.
- Empty schedule in normal view → empty state **appears**.
- Empty schedule, switch to finals view → empty state **still appears**.
- Non-empty schedule in finals view → empty state does **not** appear.
- Remove all courses/events → empty state reappears correctly.

## Issues

Closes #1777
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5230c92c-f81a-40df-8c08-1efd6b3c203b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5230c92c-f81a-40df-8c08-1efd6b3c203b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

