### PR TITLE
Review prompt: prefer lecture instructor per course/term

### DIFF
--- a/apps/antalmanac/src/stores/ReviewPromptStore.ts
+++ b/apps/antalmanac/src/stores/ReviewPromptStore.ts
@@ -3,6 +3,7 @@ import trpc from '$lib/api/trpc';
 import { type AATerm, termData } from '$lib/term';
 import { postHog } from '$providers/PostHog';
 import AppStore from '$stores/AppStore';
+import type { WebsocSectionType } from '@packages/anteater-api/types';
 import { create } from 'zustand';
 import { combine } from 'zustand/middleware';
 
@@ -28,6 +29,21 @@ type ReviewCandidate = {
 };
 
 type Step = 'enrollment-confirm' | 'review' | 'hidden';
+
+/**
+ * When several schedule rows refer to the same course in the same term (e.g. Lec + Lab),
+ * lower rank wins so we prompt for the lecture instructor instead of a lab TA. Pure-lab
+ * courses only have Lab rows, so they still surface normally.
+ */
+function reviewPromptSectionRank(sectionType: WebsocSectionType): number {
+    if (sectionType === 'Lec') {
+        return 0;
+    }
+    if (sectionType === 'Lab') {
+        return 2;
+    }
+    return 1;
+}
 
 const PAST_TERMS_WINDOW = 4;
 
@@ -65,8 +81,16 @@ export const useReviewPromptStore = create(
             if (pastTermNames.size === 0) return;
 
             const allCourses = AppStore.schedule.getAllCourses();
-            const seen = new Set<string>();
-            const candidates: ReviewCandidate[] = [];
+            const bestByCourseTerm = new Map<
+                string,
+                {
+                    courseId: string;
+                    courseTitle: string;
+                    professorId: string;
+                    term: AATerm;
+                    sectionType: WebsocSectionType;
+                }
+            >();
 
             for (const course of allCourses) {
                 const term = course.term;
@@ -92,17 +116,33 @@ export const useReviewPromptStore = create(
                 }
 
                 const courseId = `${course.deptCode} ${course.courseNumber}`;
-                const dedupKey = `${courseId}::${instructor}::${term.shortName}`;
-                if (seen.has(dedupKey)) {
-                    continue;
-                }
-                seen.add(dedupKey);
-
-                candidates.push({
+                const groupKey = `${courseId}::${term.shortName}`;
+                const next = {
                     courseId,
                     courseTitle: course.courseTitle,
                     professorId: instructor,
                     term,
+                    sectionType,
+                };
+                const prev = bestByCourseTerm.get(groupKey);
+                if (!prev || reviewPromptSectionRank(sectionType) < reviewPromptSectionRank(prev.sectionType)) {
+                    bestByCourseTerm.set(groupKey, next);
+                }
+            }
+
+            const seenCombo = new Set<string>();
+            const candidates: ReviewCandidate[] = [];
+            for (const row of bestByCourseTerm.values()) {
+                const dedupKey = `${row.courseId}::${row.professorId}::${row.term.shortName}`;
+                if (seenCombo.has(dedupKey)) {
+                    continue;
+                }
+                seenCombo.add(dedupKey);
+                candidates.push({
+                    courseId: row.courseId,
+                    courseTitle: row.courseTitle,
+                    professorId: row.professorId,
+                    term: row.term,
                 });
             }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

When building review prompt candidates from the user’s schedule, rows are now grouped by course (`dept + number`) and term. For each group we keep the schedule row with the best section-type rank: **Lec** (0) is preferred over other instructional types (1), and **Lab** (2) is last. That way a course with both lecture and lab surfaces the **lecture instructor** for the prompt instead of the lab TA. Courses that are lab-only still contribute a single candidate from their lab row.

## Test Plan

- `pnpm lint` (passes).
- `pnpm test run`: existing failures in this environment due to missing `apps/antalmanac/src/generated/termData.json`; suites that load `term.ts` do not run here. No new tests added for this store logic.

## Issues

None linked (Slack / internal product request).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6718a593-5260-444f-9017-73f26afadaf7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6718a593-5260-444f-9017-73f26afadaf7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

