### PR TITLE
chore: consolidate tRPC React client module (#1732)

### DIFF
--- a/apps/antalmanac/src/actions/AppStoreActions.ts
+++ b/apps/antalmanac/src/actions/AppStoreActions.ts
@@ -1,5 +1,5 @@
 import analyticsEnum, { analyticsIdentifyUser, logAnalytics } from '$lib/analytics/analytics';
-import trpc from '$lib/api/trpc';
+import { trpc } from '$lib/api/trpc';
 import { warnMultipleTerms } from '$lib/helpers';
 import { setLocalStorageUserId, setLocalStorageDataCache } from '$lib/localStorage';
 import { isNativeIosApp, NATIVE_IOS_REDIRECT_URI } from '$lib/platform';

--- a/apps/antalmanac/src/components/AutoSignIn.tsx
+++ b/apps/antalmanac/src/components/AutoSignIn.tsx
@@ -1,4 +1,4 @@
-import trpc from '$lib/api/trpc';
+import { trpc } from '$lib/api/trpc';
 import { hasSsoCookie } from '$lib/ssoCookie';
 import { useSessionStore } from '$stores/SessionStore';
 import { useEffect, useRef } from 'react';

--- a/apps/antalmanac/src/components/Header/Import.tsx
+++ b/apps/antalmanac/src/components/Header/Import.tsx
@@ -9,7 +9,7 @@ import { AlertDialog } from '$components/AlertDialog';
 import { TermSelector } from '$components/RightPane/CoursePane/SearchForm/TermSelector';
 import RightPaneStore from '$components/RightPane/RightPaneStore';
 import analyticsEnum, { logAnalytics } from '$lib/analytics/analytics';
-import trpc, { trpcReact } from '$lib/api/trpc';
+import { trpc, trpcReact } from '$lib/api/trpc';
 import { QueryZotcourseError } from '$lib/customErrors';
 import { warnMultipleTerms } from '$lib/helpers';
 import {

--- a/apps/antalmanac/src/components/Header/Import.tsx
+++ b/apps/antalmanac/src/components/Header/Import.tsx
@@ -9,8 +9,7 @@ import { AlertDialog } from '$components/AlertDialog';
 import { TermSelector } from '$components/RightPane/CoursePane/SearchForm/TermSelector';
 import RightPaneStore from '$components/RightPane/RightPaneStore';
 import analyticsEnum, { logAnalytics } from '$lib/analytics/analytics';
-import trpc from '$lib/api/trpc';
-import { trpcReact } from '$lib/api/trpcReact';
+import trpc, { trpcReact } from '$lib/api/trpc';
 import { QueryZotcourseError } from '$lib/customErrors';
 import { warnMultipleTerms } from '$lib/helpers';
 import {

--- a/apps/antalmanac/src/components/Header/Save.tsx
+++ b/apps/antalmanac/src/components/Header/Save.tsx
@@ -2,7 +2,7 @@ import actionTypesStore from '$actions/ActionTypesStore';
 import { isEmptySchedule } from '$actions/AppStoreActions';
 import { SignInDialog } from '$components/dialogs/SignInDialog';
 import analyticsEnum, { logAnalytics } from '$lib/analytics/analytics';
-import { trpcReact } from '$lib/api/trpcReact';
+import { trpcReact } from '$lib/api/trpc';
 import { getErrorMessage } from '$lib/utils';
 import AppStore from '$stores/AppStore';
 import { useFallbackStore } from '$stores/FallbackStore';

--- a/apps/antalmanac/src/components/Header/Signin.tsx
+++ b/apps/antalmanac/src/components/Header/Signin.tsx
@@ -5,7 +5,7 @@ import { GoogleSignInButton } from '$components/buttons/GoogleSignInButton';
 import { getSettingsPopoverPaperSx } from '$components/Header/headerStyles';
 import { ProfileMenuButtons } from '$components/Header/ProfileMenuButtons';
 import { SettingsMenu } from '$components/Header/Settings/SettingsMenu';
-import trpc from '$lib/api/trpc';
+import { trpc } from '$lib/api/trpc';
 import { getLocalStorageUserId, getWasLoggedIn, setLocalStorageFromLoading } from '$lib/localStorage';
 import { useNotificationStore } from '$stores/NotificationStore';
 import { scheduleComponentsToggleStore } from '$stores/ScheduleComponentsToggleStore';

--- a/apps/antalmanac/src/components/Header/Signout.tsx
+++ b/apps/antalmanac/src/components/Header/Signout.tsx
@@ -2,7 +2,7 @@ import { getSettingsPopoverPaperSx } from '$components/Header/headerStyles';
 import { ProfileMenuButtons } from '$components/Header/ProfileMenuButtons';
 import { SettingsMenu } from '$components/Header/Settings/SettingsMenu';
 import analyticsEnum, { logAnalytics } from '$lib/analytics/analytics';
-import { trpcReact } from '$lib/api/trpcReact';
+import { trpcReact } from '$lib/api/trpc';
 import { getErrorMessage } from '$lib/utils';
 import { useSessionStore } from '$stores/SessionStore';
 import { useThemeStore } from '$stores/SettingsStore';

--- a/apps/antalmanac/src/components/ReviewPrompt/EnrollmentConfirmStep.tsx
+++ b/apps/antalmanac/src/components/ReviewPrompt/EnrollmentConfirmStep.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { trpcReact } from '$lib/api/trpcReact';
+import { trpcReact } from '$lib/api/trpc';
 import { useReviewPromptStore } from '$stores/ReviewPromptStore';
 import { Close } from '@mui/icons-material';
 import { Box, Button, CardActions, CardContent, CardHeader, IconButton, Typography } from '@mui/material';

--- a/apps/antalmanac/src/components/ReviewPrompt/ReviewStep.tsx
+++ b/apps/antalmanac/src/components/ReviewPrompt/ReviewStep.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import analyticsEnum, { logAnalytics } from '$lib/analytics/analytics';
-import { trpcReact } from '$lib/api/trpcReact';
+import { trpcReact } from '$lib/api/trpc';
 import { postHog } from '$providers/PostHog';
 import { REVIEW_TAGS } from '$stores/ReviewPromptStore';
 import { useReviewPromptStore } from '$stores/ReviewPromptStore';

--- a/apps/antalmanac/src/components/RightPane/CoursePane/CoursePaneRoot.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/CoursePaneRoot.tsx
@@ -3,7 +3,7 @@ import CourseRenderPane from '$components/RightPane/CoursePane/CourseRenderPane'
 import { SearchForm } from '$components/RightPane/CoursePane/SearchForm/SearchForm';
 import RightPaneStore from '$components/RightPane/RightPaneStore';
 import analyticsEnum, { logAnalytics } from '$lib/analytics/analytics';
-import { trpcReact } from '$lib/api/trpcReact';
+import { trpcReact } from '$lib/api/trpc';
 import { useCoursePaneStore } from '$stores/CoursePaneStore';
 import { openSnackbar } from '$stores/SnackbarStore';
 import { Box } from '@mui/material';

--- a/apps/antalmanac/src/components/RightPane/CoursePane/CourseRenderPane.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/CourseRenderPane.tsx
@@ -8,7 +8,7 @@ import GeDataFetchProvider from '$components/RightPane/SectionTable/GEDataFetchP
 import SectionTable from '$components/RightPane/SectionTable/SectionTable';
 import { WarningAlert } from '$components/WarningAlert';
 import analyticsEnum from '$lib/analytics/analytics';
-import trpc from '$lib/api/trpc';
+import { trpc } from '$lib/api/trpc';
 import { getLocalStorageRecruitmentDismissalTime, setLocalStorageRecruitmentDismissalTime } from '$lib/localStorage';
 import {
     getMultiGeCourseKey,

--- a/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/FuzzySearch.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/FuzzySearch.tsx
@@ -2,7 +2,7 @@ import { HorizontalRightDivider } from '$components/HorizontalRightDivider';
 import { LabeledAutocomplete } from '$components/RightPane/CoursePane/SearchForm/LabeledInputs/LabeledAutocomplete';
 import RightPaneStore from '$components/RightPane/RightPaneStore';
 import analyticsEnum, { logAnalytics } from '$lib/analytics/analytics';
-import trpc from '$lib/api/trpc';
+import { trpc } from '$lib/api/trpc';
 import { type AutocompleteInputChangeReason, type AutocompleteRenderGroupParams, Box, Typography } from '@mui/material';
 import type { AATerm, SearchResult } from '@packages/antalmanac-types';
 import { PostHog } from 'posthog-js/react';

--- a/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/SearchWithPlanner.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/SearchWithPlanner.tsx
@@ -4,7 +4,7 @@ import { PLANNER_SEARCH_PARAM } from '$components/RightPane/CoursePane/SearchFor
 import { CreateRoadmapLinkItem } from '$components/RightPane/CoursePane/SearchForm/CreateRoadmapLinkItem';
 import { LabeledAutocomplete } from '$components/RightPane/CoursePane/SearchForm/LabeledInputs/LabeledAutocomplete';
 import RightPaneStore from '$components/RightPane/RightPaneStore';
-import trpc from '$lib/api/trpc';
+import { trpc } from '$lib/api/trpc';
 import {
     getQuarterPlan,
     getRoadmapTermRelation,

--- a/apps/antalmanac/src/components/RightPane/SectionTable/CourseInfo/CourseInfoBar.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/CourseInfo/CourseInfoBar.tsx
@@ -1,7 +1,7 @@
 import PrereqTree from '$components/RightPane/SectionTable/PrereqTree';
 import { useIsMobile } from '$hooks/useIsMobile';
 import analyticsEnum, { AnalyticsCategory, logAnalytics } from '$lib/analytics/analytics';
-import trpc from '$lib/api/trpc';
+import { trpc } from '$lib/api/trpc';
 import { InfoOutlined } from '@mui/icons-material';
 import { Box, Button, Popover, Skeleton } from '@mui/material';
 import type { PrerequisiteTree } from '@packages/anteater-api/types';

--- a/apps/antalmanac/src/components/RightPane/SectionTable/GEDataFetchProvider.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/GEDataFetchProvider.tsx
@@ -1,6 +1,6 @@
 import RightPaneStore from '$components/RightPane/RightPaneStore';
 import SectionTable, { SectionTableProps } from '$components/RightPane/SectionTable/SectionTable';
-import { trpcReact } from '$lib/api/trpcReact';
+import { trpcReact } from '$lib/api/trpc';
 import AppStore from '$stores/AppStore';
 import type { AACourse } from '@packages/antalmanac-types';
 import { flattenCourses } from '@packages/anteater-api/utils';

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/GpaCell.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/GpaCell.tsx
@@ -1,7 +1,7 @@
 import { TableBodyCellContainer } from '$components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/TableBodyCellContainer';
 import { GradesPopover } from '$components/RightPane/SectionTable/SectionTablePopover/GradesPopover';
 import { useIsMobile } from '$hooks/useIsMobile';
-import { trpcReact } from '$lib/api/trpcReact';
+import { trpcReact } from '$lib/api/trpc';
 import { ButtonBase, Popover, useTheme } from '@mui/material';
 import { useCallback, useMemo, useState } from 'react';
 

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTablePopover/EnrollmentHistoryPopover.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTablePopover/EnrollmentHistoryPopover.tsx
@@ -1,5 +1,5 @@
 import { useIsMobile } from '$hooks/useIsMobile';
-import { trpcReact } from '$lib/api/trpcReact';
+import { trpcReact } from '$lib/api/trpc';
 import { parseAndSortEnrollmentHistory, type EnrollmentHistory } from '$lib/enrollmentHistory';
 import { ArrowBack, ArrowForward } from '@mui/icons-material';
 import { Box, Card, CardContent, CardHeader, IconButton, Skeleton, Tooltip, Typography } from '@mui/material';

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTablePopover/GradesPopover.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTablePopover/GradesPopover.tsx
@@ -1,4 +1,4 @@
-import { trpcReact } from '$lib/api/trpcReact';
+import { trpcReact } from '$lib/api/trpc';
 import {
     Box,
     ToggleButton,

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTablePopover/PastSyllabiPopover.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTablePopover/PastSyllabiPopover.tsx
@@ -1,5 +1,5 @@
 import { useIsMobile } from '$hooks/useIsMobile';
-import { trpcReact } from '$lib/api/trpcReact';
+import { trpcReact } from '$lib/api/trpc';
 import { OpenInNew } from '@mui/icons-material';
 import {
     Card,

--- a/apps/antalmanac/src/lib/api/endpoints.ts
+++ b/apps/antalmanac/src/lib/api/endpoints.ts
@@ -1,4 +1,4 @@
-/** Builds absolute URLs for legacy REST proxies (e.g. Mapbox). Data API calls use `getEndpoint()` in `$lib/api/trpc`. */
+/** Builds absolute URLs for legacy REST proxies (e.g. Mapbox). tRPC calls use the client in `$lib/api/trpc`. */
 function endpointTransform(path: string) {
     if (process.env.NEXT_PUBLIC_ENDPOINT) {
         return `https://${process.env.NEXT_PUBLIC_ENDPOINT}.api.antalmanac.com${path}`;

--- a/apps/antalmanac/src/lib/api/trpc.ts
+++ b/apps/antalmanac/src/lib/api/trpc.ts
@@ -22,6 +22,4 @@ export const trpcConfig = {
     ],
 };
 
-const trpc = createTRPCClient<AppRouter>(trpcConfig);
-
-export default trpc;
+export const trpc = createTRPCClient<AppRouter>(trpcConfig);

--- a/apps/antalmanac/src/lib/api/trpc.ts
+++ b/apps/antalmanac/src/lib/api/trpc.ts
@@ -1,6 +1,9 @@
 import { AppRouter } from '$src/backend/routers';
 import { createTRPCClient, httpBatchLink } from '@trpc/client';
+import { createTRPCReact } from '@trpc/react-query';
 import superjson from 'superjson';
+
+export const trpcReact = createTRPCReact<AppRouter>();
 
 export const trpcConfig = {
     links: [

--- a/apps/antalmanac/src/lib/api/trpcReact.ts
+++ b/apps/antalmanac/src/lib/api/trpcReact.ts
@@ -1,4 +1,0 @@
-import type { AppRouter } from '$src/backend/routers';
-import { createTRPCReact } from '@trpc/react-query';
-
-export const trpcReact = createTRPCReact<AppRouter>();

--- a/apps/antalmanac/src/lib/multiGeSearch.ts
+++ b/apps/antalmanac/src/lib/multiGeSearch.ts
@@ -1,5 +1,5 @@
 import { ANY_GE, GE_LIST } from '$components/RightPane/CoursePane/SearchForm/constants';
-import trpc from '$lib/api/trpc';
+import { trpc } from '$lib/api/trpc';
 import type { WebsocSearchInput } from '@packages/antalmanac-types';
 import { AACourse } from '@packages/antalmanac-types';
 import { GE, WebsocAPIResponse, WebsocDepartment, WebsocSchool } from '@packages/anteater-api/types';

--- a/apps/antalmanac/src/lib/notifications.ts
+++ b/apps/antalmanac/src/lib/notifications.ts
@@ -1,4 +1,4 @@
-import trpc from '$lib/api/trpc';
+import { trpc } from '$lib/api/trpc';
 import type { Notification } from '$stores/NotificationStore';
 import { useSessionStore } from '$stores/SessionStore';
 

--- a/apps/antalmanac/src/providers/Query.tsx
+++ b/apps/antalmanac/src/providers/Query.tsx
@@ -1,5 +1,4 @@
-import { trpcConfig } from '$lib/api/trpc';
-import { trpcReact } from '$lib/api/trpcReact';
+import { trpcConfig, trpcReact } from '$lib/api/trpc';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { useState } from 'react';
 

--- a/apps/antalmanac/src/routes/AuthPage.tsx
+++ b/apps/antalmanac/src/routes/AuthPage.tsx
@@ -1,7 +1,7 @@
 import { isEmptySchedule, mergeShortCourseSchedules } from '$actions/AppStoreActions';
 import { LoadingScreen } from '$components/LoadingScreen';
 import { analyticsIdentifyUser } from '$lib/analytics/analytics';
-import trpc, { trpcReact } from '$lib/api/trpc';
+import { trpc, trpcReact } from '$lib/api/trpc';
 import {
     getLocalStorageDataCache,
     getLocalStorageFromLoading,

--- a/apps/antalmanac/src/routes/AuthPage.tsx
+++ b/apps/antalmanac/src/routes/AuthPage.tsx
@@ -1,8 +1,7 @@
 import { isEmptySchedule, mergeShortCourseSchedules } from '$actions/AppStoreActions';
 import { LoadingScreen } from '$components/LoadingScreen';
 import { analyticsIdentifyUser } from '$lib/analytics/analytics';
-import trpc from '$lib/api/trpc';
-import { trpcReact } from '$lib/api/trpcReact';
+import trpc, { trpcReact } from '$lib/api/trpc';
 import {
     getLocalStorageDataCache,
     getLocalStorageFromLoading,

--- a/apps/antalmanac/src/routes/UnsubscribePage.tsx
+++ b/apps/antalmanac/src/routes/UnsubscribePage.tsx
@@ -1,4 +1,4 @@
-import { trpcReact } from '$lib/api/trpcReact';
+import { trpcReact } from '$lib/api/trpc';
 import { parseQuarter } from '$lib/term';
 import { Box, Button } from '@mui/material';
 import { useState } from 'react';

--- a/apps/antalmanac/src/stores/NotificationStore.ts
+++ b/apps/antalmanac/src/stores/NotificationStore.ts
@@ -1,4 +1,4 @@
-import trpc from '$lib/api/trpc';
+import { trpc } from '$lib/api/trpc';
 import { Notifications } from '$lib/notifications';
 import { getTermByYearAndQuarter } from '$lib/term';
 import { useSessionStore } from '$stores/SessionStore';

--- a/apps/antalmanac/src/stores/PlannerStore.ts
+++ b/apps/antalmanac/src/stores/PlannerStore.ts
@@ -1,4 +1,4 @@
-import trpc from '$lib/api/trpc';
+import { trpc } from '$lib/api/trpc';
 import { getDefaultTerm, getTermByYearAndQuarter, parseQuarter, termData } from '$lib/term';
 import { openSnackbar } from '$stores/SnackbarStore';
 import type { AATerm, Roadmap } from '@packages/antalmanac-types';

--- a/apps/antalmanac/src/stores/ReviewPromptStore.ts
+++ b/apps/antalmanac/src/stores/ReviewPromptStore.ts
@@ -1,5 +1,5 @@
 import analyticsEnum, { logAnalytics } from '$lib/analytics/analytics';
-import trpc from '$lib/api/trpc';
+import { trpc } from '$lib/api/trpc';
 import { type AATerm, termData } from '$lib/term';
 import { postHog } from '$providers/PostHog';
 import AppStore from '$stores/AppStore';

--- a/apps/antalmanac/src/stores/Schedules.ts
+++ b/apps/antalmanac/src/stores/Schedules.ts
@@ -1,9 +1,9 @@
-import trpc from '$lib/api/trpc';
+import { trpc } from '$lib/api/trpc';
 import { getDefaultTerm, getTermByShortName } from '$lib/term';
-import { getColorForNewSection, getCourseId, groupCourseSections } from '$stores/scheduleHelpers';
-import type { AATerm } from '@packages/antalmanac-types';
 import { moveArrayElements } from '$lib/utils';
+import { getColorForNewSection, getCourseId, groupCourseSections } from '$stores/scheduleHelpers';
 import { openSnackbar } from '$stores/SnackbarStore';
+import type { AATerm } from '@packages/antalmanac-types';
 import type {
     Schedule,
     ScheduleCourse,

--- a/apps/antalmanac/src/stores/SessionStore.ts
+++ b/apps/antalmanac/src/stores/SessionStore.ts
@@ -1,4 +1,4 @@
-import trpc from '$lib/api/trpc';
+import { trpc } from '$lib/api/trpc';
 import { setWasLoggedIn } from '$lib/localStorage';
 import { clearSsoCookie } from '$lib/ssoCookie';
 import { usePlannerStore } from '$stores/PlannerStore';


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This change completes the remaining cleanup from the React Query and tRPC migration work tracked in #1732. The `createTRPCReact` setup now lives alongside the vanilla `createTRPCClient` configuration in `apps/antalmanac/src/lib/api/trpc.ts`, and the redundant `trpcReact.ts` file is removed. All imports are updated to use the single module. The vanilla client is exported as **named** `trpc` (no default export), alongside `trpcReact` and `trpcConfig`. The file header on `endpoints.ts` is corrected: it previously mentioned a `getEndpoint()` helper that does not exist in the tRPC client module.

## Test Plan

- `pnpm lint` (passes locally).

## Issues

Closes #1732
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a07606ee-eaec-4788-8473-ae953bf806a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a07606ee-eaec-4788-8473-ae953bf806a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

