### PR TITLE
Fix legacy term data path

### DIFF
--- a/apps/antalmanac/scripts/fetch-term-data.ts
+++ b/apps/antalmanac/scripts/fetch-term-data.ts
@@ -1,11 +1,11 @@
 import 'dotenv/config';
-import { mkdir, unlink, writeFile } from 'node:fs/promises';
+import { mkdir, writeFile } from 'node:fs/promises';
 
 import { AATerm } from '@packages/antalmanac-types';
 import { createClient } from '@packages/anteater-api/client';
 import type { CalendarTerm, Quarter, Year } from '@packages/anteater-api/types';
 
-import { GENERATED_DIR, LEGACY_TERM_DATA_TS, TERM_DATA_FILE } from './lib/paths.js';
+import { GENERATED_DIR, TERM_DATA_FILE } from './lib/paths.js';
 
 const aapiClient = createClient({ apiKey: process.env.ANTEATER_API_KEY });
 
@@ -41,20 +41,7 @@ function serializeTerm(term: CalendarTerm) {
     };
 }
 
-async function removeLegacyTermDataTs() {
-    try {
-        await unlink(LEGACY_TERM_DATA_TS);
-        console.log(`Removed legacy ${LEGACY_TERM_DATA_TS} (replaced by term.ts + generated termData.json).`);
-    } catch (e) {
-        if ((e as NodeJS.ErrnoException).code !== 'ENOENT') {
-            throw e;
-        }
-    }
-}
-
 async function main() {
-    await removeLegacyTermDataTs();
-
     console.log('Fetching all calendar terms from Anteater API...');
     const calendarTerms = await aapiClient.calendar.all();
     console.log(`Fetched ${calendarTerms.length} calendar terms.`);

--- a/apps/antalmanac/scripts/fetch-term-data.ts
+++ b/apps/antalmanac/scripts/fetch-term-data.ts
@@ -1,11 +1,11 @@
 import 'dotenv/config';
-import { mkdir, writeFile } from 'node:fs/promises';
+import { mkdir, unlink, writeFile } from 'node:fs/promises';
 
 import { AATerm } from '@packages/antalmanac-types';
 import { createClient } from '@packages/anteater-api/client';
 import type { CalendarTerm, Quarter, Year } from '@packages/anteater-api/types';
 
-import { GENERATED_DIR, TERM_DATA_FILE } from './lib/paths.js';
+import { GENERATED_DIR, LEGACY_TERM_DATA_TS, TERM_DATA_FILE } from './lib/paths.js';
 
 const aapiClient = createClient({ apiKey: process.env.ANTEATER_API_KEY });
 
@@ -41,7 +41,20 @@ function serializeTerm(term: CalendarTerm) {
     };
 }
 
+async function removeLegacyTermDataTs() {
+    try {
+        await unlink(LEGACY_TERM_DATA_TS);
+        console.log(`Removed legacy ${LEGACY_TERM_DATA_TS} (replaced by term.ts + generated termData.json).`);
+    } catch (e) {
+        if ((e as NodeJS.ErrnoException).code !== 'ENOENT') {
+            throw e;
+        }
+    }
+}
+
 async function main() {
+    await removeLegacyTermDataTs();
+
     console.log('Fetching all calendar terms from Anteater API...');
     const calendarTerms = await aapiClient.calendar.all();
     console.log(`Fetched ${calendarTerms.length} calendar terms.`);

--- a/apps/antalmanac/scripts/lib/paths.ts
+++ b/apps/antalmanac/scripts/lib/paths.ts
@@ -11,5 +11,3 @@ export const TERM_DATA_FILE = join(GENERATED_DIR, 'termData.json');
 export const DEPARTMENTS_FILE = join(GENERATED_DIR, 'departments.json');
 export const SEARCH_DATA_FILE = join(GENERATED_DIR, 'searchData.json');
 export const DEPLOYED_TERMS_FILE = join(GENERATED_DIR, 'deployed_terms.json');
-/** Pre-refactor source file; safe to remove if present after migrating to `term.ts` + generated JSON. */
-export const LEGACY_TERM_DATA_TS = join(GENERATED_DIR, 'termData.ts');

--- a/apps/antalmanac/scripts/lib/paths.ts
+++ b/apps/antalmanac/scripts/lib/paths.ts
@@ -11,3 +11,5 @@ export const TERM_DATA_FILE = join(GENERATED_DIR, 'termData.json');
 export const DEPARTMENTS_FILE = join(GENERATED_DIR, 'departments.json');
 export const SEARCH_DATA_FILE = join(GENERATED_DIR, 'searchData.json');
 export const DEPLOYED_TERMS_FILE = join(GENERATED_DIR, 'deployed_terms.json');
+/** Pre-refactor source file; safe to remove if present after migrating to `term.ts` + generated JSON. */
+export const LEGACY_TERM_DATA_TS = join(GENERATED_DIR, 'termData.ts');

--- a/apps/antalmanac/scripts/lib/paths.ts
+++ b/apps/antalmanac/scripts/lib/paths.ts
@@ -12,4 +12,4 @@ export const DEPARTMENTS_FILE = join(GENERATED_DIR, 'departments.json');
 export const SEARCH_DATA_FILE = join(GENERATED_DIR, 'searchData.json');
 export const DEPLOYED_TERMS_FILE = join(GENERATED_DIR, 'deployed_terms.json');
 /** Pre-refactor source file; safe to remove if present after migrating to `term.ts` + generated JSON. */
-export const LEGACY_TERM_DATA_TS = join(appRoot, 'src/lib/termData.ts');
+export const LEGACY_TERM_DATA_TS = join(GENERATED_DIR, 'termData.ts');


### PR DESCRIPTION
## Summary

Delete the generated `termData.ts` instead of the actual source file, which git already knows about.

## Test Plan

fetch-term-data.ts works

## Issues

Closes #

<!-- [Optional]
## Future Followup
-->
