### PR TITLE
refactor: move auth/onboarding localStorage to sessionStorage

### DIFF
--- a/apps/antalmanac/src/actions/AppStoreActions.ts
+++ b/apps/antalmanac/src/actions/AppStoreActions.ts
@@ -1,7 +1,8 @@
 import analyticsEnum, { analyticsIdentifyUser, logAnalytics } from '$lib/analytics/analytics';
 import { trpc } from '$lib/api/trpc';
+import { setPendingScheduleMerge } from '$lib/authSessionStorage';
 import { warnMultipleTerms } from '$lib/helpers';
-import { setLocalStorageUserId, setLocalStorageDataCache } from '$lib/localStorage';
+import { setLocalStorageUserId } from '$lib/localStorage';
 import { isNativeIosApp, NATIVE_IOS_REDIRECT_URI } from '$lib/platform';
 import { getErrorMessage } from '$lib/utils';
 import AppStore from '$stores/AppStore';
@@ -381,17 +382,18 @@ export const loadSchedule = async ({ prefetched, postHog }: LoadScheduleOptions)
     }
 };
 
-const cacheSchedule = () => {
+const cacheScheduleForAuthMerge = () => {
     const scheduleSaveState = AppStore.schedule.getScheduleAsSaveState().schedules;
     if (!isEmptySchedule(scheduleSaveState)) {
-        setLocalStorageDataCache(JSON.stringify(scheduleSaveState));
+        setPendingScheduleMerge(JSON.stringify(scheduleSaveState));
     }
 };
 
 export const loginUser = async ({
     provider = 'google',
     postHog,
-}: { provider?: 'google' | 'apple'; postHog?: PostHog } = {}) => {
+    mergeScheduleOnAuth = false,
+}: { provider?: 'google' | 'apple'; postHog?: PostHog; mergeScheduleOnAuth?: boolean } = {}) => {
     try {
         const redirectUri = isNativeIosApp() ? NATIVE_IOS_REDIRECT_URI : undefined;
         const returnTo = `${window.location.pathname}${window.location.search}${window.location.hash}`;
@@ -405,7 +407,9 @@ export const loginUser = async ({
                 category: analyticsEnum.auth,
                 action: analyticsEnum.auth.actions.SIGN_IN,
             });
-            cacheSchedule();
+            if (mergeScheduleOnAuth) {
+                cacheScheduleForAuthMerge();
+            }
             window.location.href = authUrl.toString();
         }
     } catch (error) {

--- a/apps/antalmanac/src/components/Header/Header.tsx
+++ b/apps/antalmanac/src/components/Header/Header.tsx
@@ -5,11 +5,11 @@ import { Save } from '$components/Header/Save';
 import { Signin } from '$components/Header/Signin';
 import { Signout } from '$components/Header/Signout';
 import {
-    getLocalStorageDataCache,
-    getLocalStorageImportedUser,
-    removeLocalStorageDataCache,
-    removeLocalStorageImportedUser,
-} from '$lib/localStorage';
+    getImportedGuestUsername,
+    getPendingScheduleMerge,
+    removeImportedGuestUsername,
+    removePendingScheduleMerge,
+} from '$lib/authSessionStorage';
 import { BLUE } from '$src/globals';
 import { useIsMobile } from '$src/hooks/useIsMobile';
 import { useSessionStore } from '$stores/SessionStore';
@@ -20,13 +20,13 @@ import { useCallback, useEffect, useState } from 'react';
 export function Header() {
     const [openSuccessfulSaved, setOpenSuccessfulSaved] = useState(false);
     const [openSignoutDialog, setOpenSignoutDialog] = useState(false);
-    const importedUser = getLocalStorageImportedUser() ?? '';
+    const importedUser = getImportedGuestUsername() ?? '';
     const sessionIsValid = useSessionStore((store) => store.sessionIsValid);
     const isMobile = useIsMobile();
 
     const clearStorage = useCallback(() => {
-        removeLocalStorageImportedUser();
-        removeLocalStorageDataCache();
+        removeImportedGuestUsername();
+        removePendingScheduleMerge();
     }, []);
 
     const handleCloseSuccessfulSaved = () => {
@@ -44,11 +44,11 @@ export function Header() {
     };
 
     useEffect(() => {
-        const dataCache = getLocalStorageDataCache() ?? '';
+        const pendingScheduleMerge = getPendingScheduleMerge() ?? '';
 
         if (importedUser !== '' && sessionIsValid) {
             setOpenSuccessfulSaved(true);
-        } else if (dataCache !== '' && sessionIsValid) {
+        } else if (pendingScheduleMerge !== '' && sessionIsValid) {
             openSnackbar('success', `Unsaved changes have been saved to your account!`);
             clearStorage();
         }

--- a/apps/antalmanac/src/components/Header/Import.tsx
+++ b/apps/antalmanac/src/components/Header/Import.tsx
@@ -10,15 +10,16 @@ import { TermSelector } from '$components/RightPane/CoursePane/SearchForm/TermSe
 import RightPaneStore from '$components/RightPane/RightPaneStore';
 import analyticsEnum, { logAnalytics } from '$lib/analytics/analytics';
 import { trpc, trpcReact } from '$lib/api/trpc';
+import {
+    getLegacyGuestUserIdForImport,
+    getPendingScheduleMerge,
+    hasPendingFirstSigninImport,
+    removeLegacyGuestUserIdForImport,
+    removePendingFirstSigninImport,
+} from '$lib/authSessionStorage';
 import { QueryZotcourseError } from '$lib/customErrors';
 import { warnMultipleTerms } from '$lib/helpers';
-import {
-    getLocalStorageDataCache,
-    getLocalStorageOnFirstSignin,
-    getLocalStorageUserId,
-    removeLocalStorageOnFirstSignin,
-    removeLocalStorageUserId,
-} from '$lib/localStorage';
+import { removeLocalStorageUserId } from '$lib/localStorage';
 import { processZotcourseResponse } from '$lib/zotcourse';
 import { BLUE, LIGHT_BLUE } from '$src/globals';
 import AppStore from '$stores/AppStore';
@@ -642,19 +643,19 @@ export function Import() {
     );
 
     const handleFirstTimeSignin = useCallback(async () => {
-        const newUserFlag = getLocalStorageOnFirstSignin() ?? '';
-        if (newUserFlag !== '') {
-            const savedUserId = getLocalStorageUserId();
+        if (hasPendingFirstSigninImport()) {
+            const savedUserId = getLegacyGuestUserIdForImport();
             if (savedUserId) setAAUsername(savedUserId);
             handleOpen();
-            removeLocalStorageOnFirstSignin();
+            removePendingFirstSigninImport();
+            removeLegacyGuestUserIdForImport();
             removeLocalStorageUserId();
             setImportSource(ImportSource.AA_USERNAME_IMPORT);
         }
     }, [handleOpen]);
 
     useEffect(() => {
-        if (sessionIsValid && getLocalStorageDataCache() === null) {
+        if (sessionIsValid && getPendingScheduleMerge() === null) {
             handleFirstTimeSignin();
         }
     }, [handleFirstTimeSignin, sessionIsValid]);

--- a/apps/antalmanac/src/components/Header/Signin.tsx
+++ b/apps/antalmanac/src/components/Header/Signin.tsx
@@ -6,7 +6,8 @@ import { getSettingsPopoverPaperSx } from '$components/Header/headerStyles';
 import { ProfileMenuButtons } from '$components/Header/ProfileMenuButtons';
 import { SettingsMenu } from '$components/Header/Settings/SettingsMenu';
 import { trpc } from '$lib/api/trpc';
-import { getLocalStorageUserId, getWasLoggedIn, setLocalStorageFromLoading } from '$lib/localStorage';
+import { getPreviouslyLoggedIn } from '$lib/authSessionStorage';
+import { getLocalStorageUserId } from '$lib/localStorage';
 import { useNotificationStore } from '$stores/NotificationStore';
 import { scheduleComponentsToggleStore } from '$stores/ScheduleComponentsToggleStore';
 import { useSessionStore } from '$stores/SessionStore';
@@ -112,7 +113,7 @@ export const Signin = () => {
 
             if (validSession) {
                 await loadSchedule({ prefetched: prefetchedUserData, postHog });
-            } else if (getWasLoggedIn()) {
+            } else if (getPreviouslyLoggedIn()) {
                 setAlertMessage(ALERT_MESSAGES.SESSION_EXPIRED);
                 setOpenalert(true);
             } else if (userID && userID !== '') {
@@ -129,7 +130,6 @@ export const Signin = () => {
 
     const handleLogin = (provider: 'google' | 'apple' = 'google') => {
         loginUser({ provider, postHog });
-        setLocalStorageFromLoading('true');
     };
 
     const enterEvent = useCallback(

--- a/apps/antalmanac/src/components/ScheduleManagement/ScheduleManagement.tsx
+++ b/apps/antalmanac/src/components/ScheduleManagement/ScheduleManagement.tsx
@@ -1,7 +1,7 @@
 import { ScheduleManagementContent } from '$components/ScheduleManagement/ScheduleManagementContent';
 import { ScheduleManagementTabs } from '$components/ScheduleManagement/ScheduleManagementTabs';
 import { useIsMobile } from '$hooks/useIsMobile';
-import { getWasLoggedIn } from '$lib/localStorage';
+import { getPreviouslyLoggedIn } from '$lib/authSessionStorage';
 import { shouldSearchPlannerFromParams } from '$lib/plannerHelpers';
 import AppStore from '$stores/AppStore';
 import { paramsAreInURL } from '$stores/CoursePaneStore';
@@ -59,7 +59,7 @@ export function ScheduleManagement() {
             return;
         }
 
-        const hasSession = useSessionStore.getState().sessionIsValid || getWasLoggedIn();
+        const hasSession = useSessionStore.getState().sessionIsValid || getPreviouslyLoggedIn();
         const urlHasManualSearchParams = paramsAreInURL();
         const hasLocalScheduleData = () =>
             AppStore.getAddedCourses().length > 0 || AppStore.getCustomEvents().length > 0;

--- a/apps/antalmanac/src/components/dialogs/SignInDialog.tsx
+++ b/apps/antalmanac/src/components/dialogs/SignInDialog.tsx
@@ -57,8 +57,12 @@ export function SignInDialog(props: SignInDialogProps) {
                             All changes made will be saved to your account
                         </Alert>
                     )}
-                    <GoogleSignInButton onClick={() => loginUser({ provider: 'google', postHog })} />
-                    <AppleSignInButton onClick={() => loginUser({ provider: 'apple', postHog })} />
+                    <GoogleSignInButton
+                        onClick={() => loginUser({ provider: 'google', postHog, mergeScheduleOnAuth: true })}
+                    />
+                    <AppleSignInButton
+                        onClick={() => loginUser({ provider: 'apple', postHog, mergeScheduleOnAuth: true })}
+                    />
                 </Stack>
             </DialogContent>
         </Dialog>

--- a/apps/antalmanac/src/lib/authSessionStorage.ts
+++ b/apps/antalmanac/src/lib/authSessionStorage.ts
@@ -1,0 +1,105 @@
+/**
+ * Ephemeral auth/onboarding state that only needs to survive the OAuth redirect
+ * (same tab). Prefer this over localStorage for handoff data between login and /auth.
+ */
+enum AuthSessionStorageKeys {
+    pendingScheduleMerge = 'aa_pendingScheduleMerge',
+    importedGuestUsername = 'aa_importedGuestUsername',
+    pendingFirstSigninImport = 'aa_pendingFirstSigninImport',
+    legacyGuestUserIdForImport = 'aa_legacyGuestUserIdForImport',
+    previouslyLoggedIn = 'aa_previouslyLoggedIn',
+}
+
+const ASK = AuthSessionStorageKeys;
+
+function getSessionStorage(): Storage | null {
+    if (typeof window === 'undefined' || typeof window.sessionStorage === 'undefined') {
+        return null;
+    }
+    return window.sessionStorage;
+}
+
+export function setPendingScheduleMerge(value: string) {
+    getSessionStorage()?.setItem(ASK.pendingScheduleMerge, value);
+}
+
+export function getPendingScheduleMerge(): string | null {
+    return getSessionStorage()?.getItem(ASK.pendingScheduleMerge) ?? null;
+}
+
+export function removePendingScheduleMerge() {
+    getSessionStorage()?.removeItem(ASK.pendingScheduleMerge);
+}
+
+export function setImportedGuestUsername(value: string) {
+    getSessionStorage()?.setItem(ASK.importedGuestUsername, value);
+}
+
+export function getImportedGuestUsername(): string | null {
+    return getSessionStorage()?.getItem(ASK.importedGuestUsername) ?? null;
+}
+
+export function removeImportedGuestUsername() {
+    getSessionStorage()?.removeItem(ASK.importedGuestUsername);
+}
+
+export function setPendingFirstSigninImport() {
+    getSessionStorage()?.setItem(ASK.pendingFirstSigninImport, 'true');
+}
+
+export function hasPendingFirstSigninImport(): boolean {
+    return getSessionStorage()?.getItem(ASK.pendingFirstSigninImport) === 'true';
+}
+
+export function removePendingFirstSigninImport() {
+    getSessionStorage()?.removeItem(ASK.pendingFirstSigninImport);
+}
+
+export function setLegacyGuestUserIdForImport(value: string) {
+    getSessionStorage()?.setItem(ASK.legacyGuestUserIdForImport, value);
+}
+
+export function getLegacyGuestUserIdForImport(): string | null {
+    return getSessionStorage()?.getItem(ASK.legacyGuestUserIdForImport) ?? null;
+}
+
+export function removeLegacyGuestUserIdForImport() {
+    getSessionStorage()?.removeItem(ASK.legacyGuestUserIdForImport);
+}
+
+export function clearAuthSessionHandoff() {
+    removePendingScheduleMerge();
+    removeImportedGuestUsername();
+    removePendingFirstSigninImport();
+    removeLegacyGuestUserIdForImport();
+}
+
+export function setPreviouslyLoggedIn(value: boolean) {
+    const storage = getSessionStorage();
+    if (!storage) return;
+    if (value) {
+        storage.setItem(ASK.previouslyLoggedIn, 'true');
+    } else {
+        storage.removeItem(ASK.previouslyLoggedIn);
+    }
+}
+
+export function getPreviouslyLoggedIn(): boolean {
+    return getSessionStorage()?.getItem(ASK.previouslyLoggedIn) === 'true';
+}
+
+/** Remove stale auth keys that previously lived in localStorage. */
+export function migrateStaleAuthLocalStorageKeys() {
+    if (typeof window === 'undefined') {
+        return;
+    }
+
+    if (window.localStorage.getItem('wasLoggedIn') === 'true') {
+        setPreviouslyLoggedIn(true);
+    }
+
+    const staleKeys = ['fromLoading', 'dataCache', 'importedUser', 'newUser', 'wasLoggedIn'] as const;
+    for (const key of staleKeys) {
+        window.localStorage.removeItem(key);
+    }
+}

--- a/apps/antalmanac/src/lib/localStorage.ts
+++ b/apps/antalmanac/src/lib/localStorage.ts
@@ -16,64 +16,21 @@ enum LocalStorageKeys {
     pwaDismissalTime = 'pwaDismissalTime',
     /** @deprecated Session token is now stored in an HttpOnly cookie (aa_session). */
     sessionId = 'sessionId',
-    wasLoggedIn = 'wasLoggedIn',
-    dataCache = 'dataCache',
-    newUser = 'newUser',
-    importedUser = 'importedUser',
+    /** @deprecated Auth handoff flag removed in favor of skipping schedule cache on header sign-in. */
     fromLoading = 'fromLoading',
+    /** @deprecated OAuth schedule merge payload moved to sessionStorage (see authSessionStorage). */
+    dataCache = 'dataCache',
+    /** @deprecated First-sign-in import prompt moved to sessionStorage (see authSessionStorage). */
+    newUser = 'newUser',
+    /** @deprecated Post-import success dialog username moved to sessionStorage (see authSessionStorage). */
+    importedUser = 'importedUser',
+    /** @deprecated Replaced by sessionStorage via authSessionStorage.previouslyLoggedIn. */
+    wasLoggedIn = 'wasLoggedIn',
     tempSaveData = 'tempSaveData',
     skeletonBlueprint = 'skeletonBlueprint',
 }
 
 const LSK = LocalStorageKeys;
-
-export function setLocalStorageFromLoading(value: string) {
-    window.localStorage.setItem(LSK.fromLoading, value);
-}
-
-export function getLocalStorageFromLoading() {
-    return window.localStorage.getItem(LSK.fromLoading);
-}
-
-export function removeLocalStorageFromLoading() {
-    window.localStorage.removeItem(LSK.fromLoading);
-}
-
-export function setLocalStorageImportedUser(value: string) {
-    window.localStorage.setItem(LSK.importedUser, value);
-}
-
-export function getLocalStorageImportedUser() {
-    return window.localStorage.getItem(LSK.importedUser);
-}
-
-export function removeLocalStorageImportedUser() {
-    window.localStorage.removeItem(LSK.importedUser);
-}
-
-export function setLocalStorageOnFirstSignin(value: string) {
-    window.localStorage.setItem(LSK.newUser, value);
-}
-
-export function getLocalStorageOnFirstSignin() {
-    return window.localStorage.getItem(LSK.newUser);
-}
-
-export function removeLocalStorageOnFirstSignin() {
-    window.localStorage.removeItem(LSK.newUser);
-}
-
-export function setLocalStorageDataCache(value: string) {
-    window.localStorage.setItem(LSK.dataCache, value);
-}
-
-export function getLocalStorageDataCache() {
-    return window.localStorage.getItem(LSK.dataCache);
-}
-
-export function removeLocalStorageDataCache() {
-    window.localStorage.removeItem(LSK.dataCache);
-}
 
 export function setLocalStorageUserId(value: string) {
     window.localStorage.setItem(LSK.userId, value);
@@ -85,18 +42,6 @@ export function getLocalStorageUserId() {
 
 export function removeLocalStorageUserId() {
     window.localStorage.removeItem(LSK.userId);
-}
-
-export function getWasLoggedIn(): boolean {
-    return window.localStorage.getItem(LSK.wasLoggedIn) === 'true';
-}
-
-export function setWasLoggedIn(value: boolean) {
-    if (value) {
-        window.localStorage.setItem(LSK.wasLoggedIn, 'true');
-    } else {
-        window.localStorage.removeItem(LSK.wasLoggedIn);
-    }
 }
 
 // Helper functions for patchNotesKey

--- a/apps/antalmanac/src/routes/AuthPage.tsx
+++ b/apps/antalmanac/src/routes/AuthPage.tsx
@@ -3,16 +3,14 @@ import { LoadingScreen } from '$components/LoadingScreen';
 import { analyticsIdentifyUser } from '$lib/analytics/analytics';
 import { trpc, trpcReact } from '$lib/api/trpc';
 import {
-    getLocalStorageDataCache,
-    getLocalStorageFromLoading,
-    setLocalStorageImportedUser,
-    getLocalStorageUserId,
-    removeLocalStorageUserId,
-    removeLocalStorageImportedUser,
-    removeLocalStorageDataCache,
-    removeLocalStorageFromLoading,
-    setLocalStorageOnFirstSignin,
-} from '$lib/localStorage';
+    clearAuthSessionHandoff,
+    getPendingScheduleMerge,
+    removePendingScheduleMerge,
+    setImportedGuestUsername,
+    setLegacyGuestUserIdForImport,
+    setPendingFirstSigninImport,
+} from '$lib/authSessionStorage';
+import { getLocalStorageUserId, removeLocalStorageUserId } from '$lib/localStorage';
 import { clearSsoCookie, setSsoCookie } from '$lib/ssoCookie';
 import AppStore from '$stores/AppStore';
 import { usePostHog } from 'posthog-js/react';
@@ -59,12 +57,14 @@ export function AuthPage() {
 
             analyticsIdentifyUser(postHog, userId);
 
-            const fromLoading = getLocalStorageFromLoading() ?? '';
-            const savedUserId = getLocalStorageUserId() ?? '';
-            const savedData = getLocalStorageDataCache() ?? '';
+            const legacyGuestUserId = getLocalStorageUserId() ?? '';
+            const pendingScheduleMerge = getPendingScheduleMerge() ?? '';
 
             if (newUser) {
-                setLocalStorageOnFirstSignin('true');
+                setPendingFirstSigninImport();
+                if (legacyGuestUserId !== '') {
+                    setLegacyGuestUserIdForImport(legacyGuestUserId);
+                }
             } else {
                 removeLocalStorageUserId();
             }
@@ -76,54 +76,42 @@ export function AuthPage() {
 
             setSsoCookie();
 
-            // load schedule without saving any changes
-            if (fromLoading !== '') {
-                removeLocalStorageFromLoading();
-                removeLocalStorageDataCache();
-                removeLocalStorageImportedUser();
+            if (pendingScheduleMerge === '') {
+                clearAuthSessionHandoff();
                 window.location.href = returnUrl;
                 return;
             }
 
-            // no changes to save
-            if (savedUserId === '' && savedData === '') {
-                removeLocalStorageDataCache();
-                removeLocalStorageImportedUser();
-                window.location.href = returnUrl;
-                return;
+            const userData = await trpc.schedule.get.query();
+            const scheduleSaveState = AppStore.schedule.getScheduleAsSaveState();
+
+            if (legacyGuestUserId !== '') {
+                await flagImported({ username: legacyGuestUserId });
+                setImportedGuestUsername(legacyGuestUserId);
             }
 
-            // handle unsaved changes
-            if (savedData !== '') {
-                const userData = await trpc.schedule.get.query();
-                const scheduleSaveState = AppStore.schedule.getScheduleAsSaveState();
+            const data = JSON.parse(pendingScheduleMerge);
 
-                if (savedUserId !== '') {
-                    await flagImported({ username: savedUserId });
-                    setLocalStorageImportedUser(savedUserId);
+            if (userData !== null && isEmptySchedule(userData.userData.schedules)) {
+                scheduleSaveState.schedules = data;
+            } else {
+                const saveState = userData && 'userData' in userData ? userData.userData : userData;
+                if (saveState !== null) {
+                    mergeShortCourseSchedules(saveState.schedules, data, '(import)-');
+                    scheduleSaveState.schedules = saveState.schedules;
+                    scheduleSaveState.scheduleIndex = saveState.schedules.length - 1;
                 }
-
-                const data = JSON.parse(savedData);
-
-                if (userData !== null && isEmptySchedule(userData.userData.schedules)) {
-                    scheduleSaveState.schedules = data;
-                } else {
-                    const saveState = userData && 'userData' in userData ? userData.userData : userData;
-                    if (saveState !== null) {
-                        mergeShortCourseSchedules(saveState.schedules, data, '(import)-');
-                        scheduleSaveState.schedules = saveState.schedules;
-                        scheduleSaveState.scheduleIndex = saveState.schedules.length - 1;
-                    }
-                }
-
-                await saveSchedule({
-                    userData: scheduleSaveState,
-                });
             }
+
+            await saveSchedule({
+                userData: scheduleSaveState,
+            });
+            removePendingScheduleMerge();
             window.location.href = returnUrl;
         } catch (error) {
             console.error('Error during authentication', error);
             clearSsoCookie();
+            clearAuthSessionHandoff();
             window.location.href = '/';
         }
     }, [searchParams, postHog, handleGoogleCallback, flagImported, saveSchedule]);

--- a/apps/antalmanac/src/stores/SessionStore.ts
+++ b/apps/antalmanac/src/stores/SessionStore.ts
@@ -1,5 +1,5 @@
 import { trpc } from '$lib/api/trpc';
-import { setWasLoggedIn } from '$lib/localStorage';
+import { migrateStaleAuthLocalStorageKeys, setPreviouslyLoggedIn } from '$lib/authSessionStorage';
 import { clearSsoCookie } from '$lib/ssoCookie';
 import { usePlannerStore } from '$stores/PlannerStore';
 import { TRPCClientError } from '@trpc/client';
@@ -21,6 +21,7 @@ interface SessionState {
 export const useSessionStore = create<SessionState>((set) => {
     // Clean up stale localStorage token from before the cookie migration
     window.localStorage.removeItem('sessionId');
+    migrateStaleAuthLocalStorageKeys();
 
     return {
         userId: null,
@@ -47,7 +48,7 @@ export const useSessionStore = create<SessionState>((set) => {
 
                 usePlannerStore.getState().loadPlannerRoadmaps();
 
-                setWasLoggedIn(true);
+                setPreviouslyLoggedIn(true);
                 return true;
             } catch (error) {
                 const isUnauthorized = error instanceof TRPCClientError && error.data?.code === 'UNAUTHORIZED';
@@ -70,7 +71,7 @@ export const useSessionStore = create<SessionState>((set) => {
         },
 
         clearSession: () => {
-            setWasLoggedIn(false);
+            setPreviouslyLoggedIn(false);
             clearSsoCookie();
             set({
                 userId: null,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Refactors auth and onboarding state that was unnecessarily persisted in `localStorage`, addressing #1808.

- Adds `authSessionStorage.ts` for ephemeral OAuth handoff data (schedule merge payload, first-sign-in import prompt, imported guest username, previously-logged-in flag).
- **Removes `fromLoading` entirely** — header sign-in no longer caches a schedule that was always discarded on return; only `SignInDialog` flows pass `mergeScheduleOnAuth: true` to cache schedules for merge.
- Moves `wasLoggedIn` to sessionStorage with one-time migration/cleanup of stale localStorage keys on session store init.
- Keeps `userID` in localStorage for legacy guest "remember me" only.
- Deprecated auth `localStorage` enum entries retain JSDoc; accessor functions are removed.

## Test Plan

- [ ] Sign in from header (Google/Apple) with an existing guest schedule — account loads without spurious merge
- [ ] Sign in via Save/Notification SignInDialog with courses on calendar — guest schedule merges into account
- [ ] New user OAuth with legacy guest ID — import dialog opens with prefilled username
- [ ] Guest schedule import after OAuth — success dialog shows imported username
- [ ] Expired session after prior login — "session expired" alert still appears (same tab)
- [ ] `pnpm lint` passes

## Issues

Closes #1808
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ad6ff76e-4fab-4543-ad92-877f83181389"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ad6ff76e-4fab-4543-ad92-877f83181389"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

