### PR TITLE
fix(added-courses): prevent drag handle from shrinking in flex row

### DIFF
--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTable.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTable.tsx
@@ -137,7 +137,13 @@ function SectionTable({
                     <Button
                         variant="contained"
                         color="secondary"
-                        sx={{ padding: 0, minWidth: 0, minHeight: 0, cursor: 'inherit' }}
+                        sx={{
+                            padding: 0,
+                            minWidth: 0,
+                            minHeight: 0,
+                            cursor: 'inherit',
+                            flexShrink: 0,
+                        }}
                     >
                         <SortableList.DragHandle sx={{ height: '100%' }} iconSx={{ color: 'inherit' }} />
                     </Button>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The added-courses `SectionTable` header is a horizontal flex row. The drag handle is wrapped in a MUI `Button` that was allowed to shrink (`flex-shrink` defaults to 1), which could squeeze the handle when the course title and action buttons need space. This change sets `flexShrink: 0` on that button so the drag affordance keeps a stable size.

## Test Plan

- `pnpm lint`

## Issues

N/A
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-74241297-b198-456a-967b-6e0079c1de76"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-74241297-b198-456a-967b-6e0079c1de76"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

