### PR TITLE
refactor: decouple termData-independent helpers from term.ts

### DIFF
--- a/apps/antalmanac/scripts/get-search-data.ts
+++ b/apps/antalmanac/scripts/get-search-data.ts
@@ -2,7 +2,8 @@ import 'dotenv/config';
 import { access, mkdir, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 
-import { canTermEnrollmentChange, termData } from '$lib/term';
+import { termData } from '$lib/term';
+import { canTermEnrollmentChange } from '$lib/termHelpers';
 import type { AATerm, CourseSearchResult, DepartmentSearchResult } from '@packages/antalmanac-types';
 import { createClient } from '@packages/anteater-api/client';
 import type { Course, WebsocAPIResponse, WebsocCourse, WebsocDepartment } from '@packages/anteater-api/types';

--- a/apps/antalmanac/scripts/lib/paths.ts
+++ b/apps/antalmanac/scripts/lib/paths.ts
@@ -12,4 +12,4 @@ export const DEPARTMENTS_FILE = join(GENERATED_DIR, 'departments.json');
 export const SEARCH_DATA_FILE = join(GENERATED_DIR, 'searchData.json');
 export const DEPLOYED_TERMS_FILE = join(GENERATED_DIR, 'deployed_terms.json');
 /** Pre-refactor source file; safe to remove if present after migrating to `term.ts` + generated JSON. */
-export const LEGACY_TERM_DATA_TS = join(appRoot, 'src/lib/termData.ts');
+export const LEGACY_TERM_DATA_TS = join(GENERATED_DIR, 'termData.ts');

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/action-cell/NotificationsMenu.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/action-cell/NotificationsMenu.tsx
@@ -1,12 +1,12 @@
 import { SignInDialog } from '$components/dialogs/SignInDialog';
 import { NotificationEmailTooltip } from '$components/RightPane/AddedCourses/Notifications/NotificationEmailTooltip';
 import analyticsEnum, { AANTS_ANALYTICS_ACTIONS, logAnalytics } from '$lib/analytics/analytics';
-import { canTermEnrollmentChange, type AATerm } from '$lib/term';
+import { canTermEnrollmentChange } from '$lib/termHelpers';
 import { type NotifyOn, useNotificationStore } from '$stores/NotificationStore';
 import { useSessionStore } from '$stores/SessionStore';
 import { Check, EditNotifications, NotificationAddOutlined } from '@mui/icons-material';
 import { Box, IconButton, Menu, MenuItem, Tooltip, Typography } from '@mui/material';
-import type { AASection } from '@packages/antalmanac-types';
+import type { AASection, AATerm } from '@packages/antalmanac-types';
 import type { Course } from '@packages/anteater-api/types';
 import { usePostHog } from 'posthog-js/react';
 import { memo, useCallback, useState } from 'react';

--- a/apps/antalmanac/src/lib/term.ts
+++ b/apps/antalmanac/src/lib/term.ts
@@ -1,52 +1,11 @@
 import type { CourseEvent, CustomEvent } from '$components/Calendar/CourseCalendarEvent';
 import termJson from '$generated/termData.json';
-import { parseTermShortName } from '$lib/termHelpers';
-import { QuarterSchema, type AATerm } from '@packages/antalmanac-types';
+import { parseQuarter, termSchema } from '$lib/termHelpers';
+import type { AATerm } from '@packages/antalmanac-types';
 import { Year } from '@packages/anteater-api/types';
-import { addWeeks, differenceInWeeks, setDay } from 'date-fns';
 import { z } from 'zod';
 
 export type { AATerm } from '@packages/antalmanac-types';
-
-/**
- * Parse an ISO "YYYY-MM-DD" string into a local-timezone Date,
- * avoiding UTC-vs-local shifts from `new Date(isoString)`.
- */
-function parseLocalDate(dateStr: string): Date {
-    const [y, month, day] = dateStr.split('-').map(Number);
-    return new Date(y, month - 1, day);
-}
-
-const termSchema = z
-    .object({
-        year: z.string(),
-        quarter: QuarterSchema,
-        // TODO(zod-v4): Replace refine with z.literal.template() once we upgrade to Zod v4.
-        shortName: z.string().refine((s): s is AATerm['shortName'] => parseTermShortName(s) !== undefined, {
-            message: 'shortName must be "<year> <quarter>"',
-        }),
-        longName: z.string(),
-        instructionStart: z.string().date(),
-        instructionEnd: z.string().date(),
-        finalsStart: z.string().date(),
-        finalsEnd: z.string().date(),
-        socAvailable: z.string().date(),
-        isSummerTerm: z.boolean(),
-    })
-    .transform(
-        (t): AATerm => ({
-            year: t.year,
-            quarter: t.quarter,
-            shortName: t.shortName,
-            longName: t.longName,
-            instructionStart: parseLocalDate(t.instructionStart),
-            instructionEnd: parseLocalDate(t.instructionEnd),
-            finalsStart: parseLocalDate(t.finalsStart),
-            finalsEnd: parseLocalDate(t.finalsEnd),
-            socAvailable: parseLocalDate(t.socAvailable),
-            isSummerTerm: t.isSummerTerm,
-        })
-    );
 
 const allTerms: AATerm[] = z.array(termSchema).parse(termJson);
 
@@ -72,11 +31,6 @@ export function getTermByShortName(termShortName: string): AATerm | undefined {
     return termData.find((t) => t.shortName === termShortName);
 }
 
-export function parseQuarter(rawQuarter: unknown) {
-    const quarter = QuarterSchema.safeParse(rawQuarter);
-    return quarter.success ? quarter.data : undefined;
-}
-
 export function getTermByYearAndQuarter(year: Year, rawQuarter: unknown): AATerm | undefined {
     const quarter = parseQuarter(rawQuarter);
     if (!quarter) {
@@ -87,27 +41,4 @@ export function getTermByYearAndQuarter(year: Year, rawQuarter: unknown): AATerm
 
 export function isTermAvailable(termShortName: string) {
     return termData.some((term) => term.shortName === termShortName);
-}
-
-/**
- * Enrollment can change until the drop deadline, i.e. when enrollment closes.
- * For full terms (10-week quarters), enrollment closes on the Friday of Week 2.
- * For short terms (5-week summer terms), enrollment closes on the Friday of Week 1.
- *
- * See {@link https://www.reg.uci.edu/enrollment/adc/adcpolicy.html} for full terms and
- * {@link https://summer.uci.edu/faq} for shorter summer terms.
- */
-export function canTermEnrollmentChange(term: AATerm) {
-    if (new Date().getFullYear() - term.instructionStart.getFullYear() > 1) {
-        return false;
-    }
-
-    const isTermShort = differenceInWeeks(term.finalsStart, term.instructionStart) < 9;
-    const hasWeekZero = term.instructionStart.getDay() !== 1;
-    let weeksUntilDropDeadline = isTermShort ? 0 : 1;
-    if (hasWeekZero) {
-        weeksUntilDropDeadline++;
-    }
-
-    return new Date() <= setDay(addWeeks(term.instructionStart, weeksUntilDropDeadline), 5);
 }

--- a/apps/antalmanac/src/lib/termHelpers.ts
+++ b/apps/antalmanac/src/lib/termHelpers.ts
@@ -1,5 +1,7 @@
-import { QuarterSchema } from '@packages/antalmanac-types';
+import { QuarterSchema, type AATerm } from '@packages/antalmanac-types';
 import type { Quarter, Year } from '@packages/anteater-api/types';
+import { addWeeks, differenceInWeeks, setDay } from 'date-fns';
+import { z } from 'zod';
 
 export function parseTermShortName(shortName: string): { year: Year; quarter: Quarter } | undefined {
     const parts = shortName.split(' ');
@@ -14,4 +16,72 @@ export function parseTermShortName(shortName: string): { year: Year; quarter: Qu
     }
 
     return { year, quarter: result.data };
+}
+
+/**
+ * Parse an ISO "YYYY-MM-DD" string into a local-timezone Date,
+ * avoiding UTC-vs-local shifts from `new Date(isoString)`.
+ */
+export function parseLocalDate(dateStr: string): Date {
+    const [y, month, day] = dateStr.split('-').map(Number);
+    return new Date(y, month - 1, day);
+}
+
+export function parseQuarter(rawQuarter: unknown) {
+    const quarter = QuarterSchema.safeParse(rawQuarter);
+    return quarter.success ? quarter.data : undefined;
+}
+
+export const termSchema = z
+    .object({
+        year: z.string(),
+        quarter: QuarterSchema,
+        // TODO(zod-v4): Replace refine with z.literal.template() once we upgrade to Zod v4.
+        shortName: z.string().refine((s): s is AATerm['shortName'] => parseTermShortName(s) !== undefined, {
+            message: 'shortName must be "<year> <quarter>"',
+        }),
+        longName: z.string(),
+        instructionStart: z.string().date(),
+        instructionEnd: z.string().date(),
+        finalsStart: z.string().date(),
+        finalsEnd: z.string().date(),
+        socAvailable: z.string().date(),
+        isSummerTerm: z.boolean(),
+    })
+    .transform(
+        (t): AATerm => ({
+            year: t.year,
+            quarter: t.quarter,
+            shortName: t.shortName,
+            longName: t.longName,
+            instructionStart: parseLocalDate(t.instructionStart),
+            instructionEnd: parseLocalDate(t.instructionEnd),
+            finalsStart: parseLocalDate(t.finalsStart),
+            finalsEnd: parseLocalDate(t.finalsEnd),
+            socAvailable: parseLocalDate(t.socAvailable),
+            isSummerTerm: t.isSummerTerm,
+        })
+    );
+
+/**
+ * Enrollment can change until the drop deadline, i.e. when enrollment closes.
+ * For full terms (10-week quarters), enrollment closes on the Friday of Week 2.
+ * For short terms (5-week summer terms), enrollment closes on the Friday of Week 1.
+ *
+ * See {@link https://www.reg.uci.edu/enrollment/adc/adcpolicy.html} for full terms and
+ * {@link https://summer.uci.edu/faq} for shorter summer terms.
+ */
+export function canTermEnrollmentChange(term: AATerm) {
+    if (new Date().getFullYear() - term.instructionStart.getFullYear() > 1) {
+        return false;
+    }
+
+    const isTermShort = differenceInWeeks(term.finalsStart, term.instructionStart) < 9;
+    const hasWeekZero = term.instructionStart.getDay() !== 1;
+    let weeksUntilDropDeadline = isTermShort ? 0 : 1;
+    if (hasWeekZero) {
+        weeksUntilDropDeadline++;
+    }
+
+    return new Date() <= setDay(addWeeks(term.instructionStart, weeksUntilDropDeadline), 5);
 }

--- a/apps/antalmanac/src/lib/termHelpers.ts
+++ b/apps/antalmanac/src/lib/termHelpers.ts
@@ -3,35 +3,6 @@ import type { Quarter, Year } from '@packages/anteater-api/types';
 import { addWeeks, differenceInWeeks, setDay } from 'date-fns';
 import { z } from 'zod';
 
-export function parseTermShortName(shortName: string): { year: Year; quarter: Quarter } | undefined {
-    const parts = shortName.split(' ');
-    if (parts.length !== 2) {
-        return undefined;
-    }
-
-    const [year, rawQuarter] = parts;
-    const result = QuarterSchema.safeParse(rawQuarter);
-    if (!result.success) {
-        return undefined;
-    }
-
-    return { year, quarter: result.data };
-}
-
-/**
- * Parse an ISO "YYYY-MM-DD" string into a local-timezone Date,
- * avoiding UTC-vs-local shifts from `new Date(isoString)`.
- */
-export function parseLocalDate(dateStr: string): Date {
-    const [y, month, day] = dateStr.split('-').map(Number);
-    return new Date(y, month - 1, day);
-}
-
-export function parseQuarter(rawQuarter: unknown) {
-    const quarter = QuarterSchema.safeParse(rawQuarter);
-    return quarter.success ? quarter.data : undefined;
-}
-
 export const termSchema = z
     .object({
         year: z.string(),
@@ -62,6 +33,35 @@ export const termSchema = z
             isSummerTerm: t.isSummerTerm,
         })
     );
+
+export function parseTermShortName(shortName: string): { year: Year; quarter: Quarter } | undefined {
+    const parts = shortName.split(' ');
+    if (parts.length !== 2) {
+        return undefined;
+    }
+
+    const [year, rawQuarter] = parts;
+    const result = QuarterSchema.safeParse(rawQuarter);
+    if (!result.success) {
+        return undefined;
+    }
+
+    return { year, quarter: result.data };
+}
+
+/**
+ * Parse an ISO "YYYY-MM-DD" string into a local-timezone Date,
+ * avoiding UTC-vs-local shifts from `new Date(isoString)`.
+ */
+function parseLocalDate(dateStr: string): Date {
+    const [y, month, day] = dateStr.split('-').map(Number);
+    return new Date(y, month - 1, day);
+}
+
+export function parseQuarter(rawQuarter: unknown) {
+    const quarter = QuarterSchema.safeParse(rawQuarter);
+    return quarter.success ? quarter.data : undefined;
+}
 
 /**
  * Enrollment can change until the drop deadline, i.e. when enrollment closes.

--- a/apps/antalmanac/src/routes/UnsubscribePage.tsx
+++ b/apps/antalmanac/src/routes/UnsubscribePage.tsx
@@ -1,5 +1,5 @@
 import { trpcReact } from '$lib/api/trpc';
-import { parseQuarter } from '$lib/term';
+import { parseQuarter } from '$lib/termHelpers';
 import { Box, Button } from '@mui/material';
 import { useState } from 'react';
 import { useParams, useSearchParams } from 'react-router-dom';

--- a/apps/antalmanac/src/stores/PlannerStore.ts
+++ b/apps/antalmanac/src/stores/PlannerStore.ts
@@ -1,5 +1,6 @@
 import { trpc } from '$lib/api/trpc';
-import { getDefaultTerm, getTermByYearAndQuarter, parseQuarter, termData } from '$lib/term';
+import { getDefaultTerm, getTermByYearAndQuarter, termData } from '$lib/term';
+import { parseQuarter } from '$lib/termHelpers';
 import { openSnackbar } from '$stores/SnackbarStore';
 import type { AATerm, Roadmap } from '@packages/antalmanac-types';
 import { create } from 'zustand';


### PR DESCRIPTION
follow-up to #1794. moved the remaining `termData`-independent helpers
out of `term.ts` so consumers don't transitively load
`$generated/termData.json` (and the `$components` chain via the
`CourseEvent` import) just to call `parseQuarter` or
`canTermEnrollmentChange`.

no `term.ts` re-export,`$lib/term` and `$lib/termHelpers` are
distinct entry points and consumers pick the one that matches what
they actually need.

thanks ai

## Summary

- moved `parseLocalDate`, `parseQuarter`, `termSchema`, `canTermEnrollmentChange` from `term.ts` to `termHelpers.ts`
- `term.ts` is now just the termData loader + accessors over it (`getDefaultTerm`, `getTermByShortName`, `getTermByYearAndQuarter`, `isTermAvailable`)
- `UnsubscribePage` and `NotificationsMenu` no longer import from `$lib/term`
- `PlannerStore` and `get-search-data` keep `$lib/term` for `termData` but pull helpers from `$lib/termHelpers`

## Test Plan

- [x] `pnpm --filter antalmanac exec tsc --noEmit` — no new errors vs `main`
- [x] `pnpm --filter antalmanac exec vitest run` — no new failures vs `main`
- [x] `apps/antalmanac/src/lib/termHelpers.ts` imports audited — zero `$generated`/`$components` reachability
- [ ] staging deploy goes green
- [ ] `pnpm --filter antalmanac update-terms` runs locally

## Issues

Closes #