### PR TITLE
Refactor: move missing sections warning outside of collapse

### DIFF
--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTable.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTable.tsx
@@ -190,10 +190,11 @@ function SectionTable({
                 </IconButton>
             </Box>
 
+            {missingSections?.length > 0 && (
+                <WarningAlert>Missing required sections: {missingSections.join(', ')}</WarningAlert>
+            )}
+
             <Collapse in={openContent} onExited={handleCollapseExit}>
-                {missingSections?.length > 0 && (
-                    <WarningAlert>Missing required sections: {missingSections.join(', ')}</WarningAlert>
-                )}
                 <TableContainer
                     component={Paper}
                     sx={{ margin: '0px 0px 8px 0px', width: '100%' }}


### PR DESCRIPTION
## Summary
Show the missing sections warning even if the user collapses their sections. This design will be consistent with the cancelled class warning in #1780 

## Test Plan

## Issues

Closes #

<!-- [Optional]
## Future Followup
-->
