### PR TITLE
refactor: type mergeSx reducer without `any`

### DIFF
--- a/apps/antalmanac/src/lib/helpers.ts
+++ b/apps/antalmanac/src/lib/helpers.ts
@@ -19,23 +19,29 @@ export async function clickToCopy(event: MouseEvent<HTMLElement>, sectionCode: s
     openSnackbar('success', 'WebsocSection code copied to clipboard');
 }
 
-type MergedSxItem = boolean | SystemStyleObject<Theme> | ((theme: Theme) => SystemStyleObject<Theme>);
-
 /**
  * Merges MUI sx props. Later styles override earlier ones.
  *
  * Taken from [MUI internals](https://github.com/mui/mui-x/blob/master/packages/x-date-pickers/src/internals/utils/utils.ts)
  */
-export function mergeSx(...sxProps: (SxProps<Theme> | undefined)[]): ReadonlyArray<MergedSxItem> {
-    return sxProps.reduce<MergedSxItem[]>((acc, sxProp) => {
-        if (Array.isArray(sxProp)) {
-            acc.push(...sxProp);
-        } else if (sxProp != null) {
-            acc.push(sxProp as MergedSxItem);
-        }
+export function mergeSx(
+    ...sxProps: (SxProps<Theme> | undefined)[]
+): ReadonlyArray<boolean | SystemStyleObject<Theme> | ((theme: Theme) => SystemStyleObject<Theme>)> {
+    const isFlattenedSxArray = (
+        value: SxProps<Theme>
+    ): value is ReadonlyArray<boolean | SystemStyleObject<Theme> | ((theme: Theme) => SystemStyleObject<Theme>)> =>
+        Array.isArray(value);
 
-        return acc;
-    }, []);
+    const acc: (boolean | SystemStyleObject<Theme> | ((theme: Theme) => SystemStyleObject<Theme>))[] = [];
+    for (const sxProp of sxProps) {
+        if (sxProp == null) continue;
+        if (isFlattenedSxArray(sxProp)) {
+            acc.push(...sxProp);
+        } else {
+            acc.push(sxProp);
+        }
+    }
+    return acc;
 }
 
 export const QUARTER_ORDER_IN_YEAR: Record<string, number> = {

--- a/apps/antalmanac/src/lib/helpers.ts
+++ b/apps/antalmanac/src/lib/helpers.ts
@@ -19,23 +19,23 @@ export async function clickToCopy(event: MouseEvent<HTMLElement>, sectionCode: s
     openSnackbar('success', 'WebsocSection code copied to clipboard');
 }
 
+type MergedSxItem = boolean | SystemStyleObject<Theme> | ((theme: Theme) => SystemStyleObject<Theme>);
+
 /**
  * Merges MUI sx props. Later styles override earlier ones.
  *
  * Taken from [MUI internals](https://github.com/mui/mui-x/blob/master/packages/x-date-pickers/src/internals/utils/utils.ts)
  */
-export function mergeSx(
-    ...sxProps: (SxProps<Theme> | undefined)[]
-): ReadonlyArray<boolean | SystemStyleObject<Theme> | ((theme: Theme) => SystemStyleObject<Theme>)> {
-    return sxProps.reduce((acc, sxProp) => {
+export function mergeSx(...sxProps: (SxProps<Theme> | undefined)[]): ReadonlyArray<MergedSxItem> {
+    return sxProps.reduce<MergedSxItem[]>((acc, sxProp) => {
         if (Array.isArray(sxProp)) {
             acc.push(...sxProp);
         } else if (sxProp != null) {
-            acc.push(sxProp);
+            acc.push(sxProp as MergedSxItem);
         }
 
         return acc;
-    }, [] as any);
+    }, []);
 }
 
 export const QUARTER_ORDER_IN_YEAR: Record<string, number> = {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Introduces a local type predicate so `mergeSx` can flatten `SxProps<Theme>` without `as` casts. Plain `Array.isArray` does not remove MUI’s `ReadonlyArray<…>` branch from the `SxProps` union, so a `value is ReadonlyArray<…>` guard is used to narrow the non-array case to `SystemStyleObject | theme => SystemStyleObject` before pushing. The merged fragment type stays inline on the return type and on the accumulator.

## Test Plan

- `pnpm lint`
- `pnpm exec tsc -p tsconfig.json --noEmit` (helpers.ts clean; full project still needs generated assets in CI)

## Issues

N/A
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ca1b7a9a-d93a-42c4-9898-538006e8a709"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ca1b7a9a-d93a-42c4-9898-538006e8a709"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

