### PR TITLE
refactor: Zustand useShallow pass for duplicate store subscriptions

### DIFF
--- a/apps/antalmanac/src/app/Theme.tsx
+++ b/apps/antalmanac/src/app/Theme.tsx
@@ -7,6 +7,7 @@ import { createTheme, ThemeProvider } from '@mui/material/styles';
 import { Roboto } from 'next/font/google';
 import { usePostHog } from 'posthog-js/react';
 import { useEffect, useMemo } from 'react';
+import { useShallow } from 'zustand/react/shallow';
 
 const roboto = Roboto({
     weight: ['300', '400', '500', '700'],
@@ -119,8 +120,7 @@ declare module '@mui/material/styles' {
  * sets and provides the MUI theme for the app
  */
 export default function AppThemeProvider(props: Props) {
-    const isDark = useThemeStore((store) => store.isDark);
-    const setAppTheme = useThemeStore((store) => store.setAppTheme);
+    const [isDark, setAppTheme] = useThemeStore(useShallow((store) => [store.isDark, store.setAppTheme]));
     const postHog = usePostHog();
 
     useEffect(() => {

--- a/apps/antalmanac/src/components/ReviewPrompt/EnrollmentConfirmStep.tsx
+++ b/apps/antalmanac/src/components/ReviewPrompt/EnrollmentConfirmStep.tsx
@@ -4,14 +4,16 @@ import { trpcReact } from '$lib/api/trpc';
 import { useReviewPromptStore } from '$stores/ReviewPromptStore';
 import { Close } from '@mui/icons-material';
 import { Box, Button, CardActions, CardContent, CardHeader, IconButton, Typography } from '@mui/material';
+import { useShallow } from 'zustand/react/shallow';
 
 export function EnrollmentConfirmStep() {
-    const courseId = useReviewPromptStore((s) => s.candidate?.courseId ?? '');
-    const courseTitle = useReviewPromptStore((s) => s.candidate?.courseTitle ?? '');
-    const professorId = useReviewPromptStore((s) => s.candidate?.professorId ?? '');
-    const term = useReviewPromptStore((s) => s.candidate?.term ?? null);
-    const confirm = useReviewPromptStore((s) => s.confirm);
-    const dismiss = useReviewPromptStore((s) => s.dismiss);
+    const { candidate, confirm, dismiss } = useReviewPromptStore(
+        useShallow((s) => ({ candidate: s.candidate, confirm: s.confirm, dismiss: s.dismiss }))
+    );
+    const courseId = candidate?.courseId ?? '';
+    const courseTitle = candidate?.courseTitle ?? '';
+    const professorId = candidate?.professorId ?? '';
+    const term = candidate?.term ?? null;
 
     const { mutate: dismissReview } = trpcReact.review.dismissReview.useMutation();
 

--- a/apps/antalmanac/src/components/ReviewPrompt/ReviewPrompt.tsx
+++ b/apps/antalmanac/src/components/ReviewPrompt/ReviewPrompt.tsx
@@ -6,16 +6,18 @@ import { useReviewPromptStore } from '$stores/ReviewPromptStore';
 import { useSessionStore } from '$stores/SessionStore';
 import { Paper, Snackbar } from '@mui/material';
 import { useEffect, useRef } from 'react';
+import { useShallow } from 'zustand/react/shallow';
 
 const PROMPT_DELAY_MS = 15_000;
 
 export function ReviewPrompt() {
-    const userId = useSessionStore((s) => s.userId);
-    const sessionIsValid = useSessionStore((s) => s.sessionIsValid);
+    const { userId, sessionIsValid } = useSessionStore(
+        useShallow((s) => ({ userId: s.userId, sessionIsValid: s.sessionIsValid }))
+    );
 
-    const step = useReviewPromptStore((s) => s.step);
-    const candidate = useReviewPromptStore((s) => s.candidate);
-    const initPrompt = useReviewPromptStore((s) => s.initPrompt);
+    const { step, candidate, initPrompt } = useReviewPromptStore(
+        useShallow((s) => ({ step: s.step, candidate: s.candidate, initPrompt: s.initPrompt }))
+    );
 
     const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
     const promptInitialized = useRef(false);

--- a/apps/antalmanac/src/components/ReviewPrompt/ReviewStep.tsx
+++ b/apps/antalmanac/src/components/ReviewPrompt/ReviewStep.tsx
@@ -20,6 +20,7 @@ import {
     TextField,
     Typography,
 } from '@mui/material';
+import { useShallow } from 'zustand/react/shallow';
 
 function ratingLabel(rating: number): string {
     // Aligned with RMP
@@ -57,19 +58,35 @@ function difficultyLabel(difficulty: number): string {
 }
 
 export function ReviewStep() {
-    const candidate = useReviewPromptStore((s) => s.candidate);
+    const {
+        candidate,
+        rating,
+        difficulty,
+        selectedTags,
+        setRating,
+        setDifficulty,
+        textReview,
+        setTextReview,
+        toggleTag,
+        dismiss,
+        resetReview,
+    } = useReviewPromptStore(
+        useShallow((s) => ({
+            candidate: s.candidate,
+            rating: s.rating,
+            difficulty: s.difficulty,
+            selectedTags: s.selectedTags,
+            setRating: s.setRating,
+            setDifficulty: s.setDifficulty,
+            textReview: s.textReview,
+            setTextReview: s.setTextReview,
+            toggleTag: s.toggleTag,
+            dismiss: s.dismiss,
+            resetReview: s.resetReview,
+        }))
+    );
     const courseId = candidate?.courseId ?? '';
     const professorId = candidate?.professorId ?? '';
-    const rating = useReviewPromptStore((s) => s.rating);
-    const difficulty = useReviewPromptStore((s) => s.difficulty);
-    const selectedTags = useReviewPromptStore((s) => s.selectedTags);
-    const setRating = useReviewPromptStore((s) => s.setRating);
-    const setDifficulty = useReviewPromptStore((s) => s.setDifficulty);
-    const textReview = useReviewPromptStore((s) => s.textReview);
-    const setTextReview = useReviewPromptStore((s) => s.setTextReview);
-    const toggleTag = useReviewPromptStore((s) => s.toggleTag);
-    const dismiss = useReviewPromptStore((s) => s.dismiss);
-    const resetReview = useReviewPromptStore((s) => s.resetReview);
 
     const { mutate: dismissReview } = trpcReact.review.dismissReview.useMutation();
 

--- a/apps/antalmanac/src/components/RightPane/AddedCourses/Notifications/NotificationTableRowCheckbox.tsx
+++ b/apps/antalmanac/src/components/RightPane/AddedCourses/Notifications/NotificationTableRowCheckbox.tsx
@@ -3,6 +3,7 @@ import { Notification, NotifyOn, useNotificationStore } from '$stores/Notificati
 import { TableCell, Checkbox } from '@mui/material';
 import { usePostHog } from 'posthog-js/react';
 import { memo, useCallback } from 'react';
+import { useShallow } from 'zustand/react/shallow';
 
 type NotificationTableRowCheckboxProps = Omit<Notification, 'notifyOn'> & {
     notificationKey: string;
@@ -22,10 +23,12 @@ export const NotificationTableRowCheckbox = memo(
         lastUpdatedStatus,
         lastCodes,
     }: NotificationTableRowCheckboxProps) => {
-        const status = useNotificationStore(
-            (state) => state.notifications[notificationKey]?.notifyOn[statusKey] ?? false
+        const [status, setNotifications] = useNotificationStore(
+            useShallow((state) => [
+                state.notifications[notificationKey]?.notifyOn[statusKey] ?? false,
+                state.setNotifications,
+            ])
         );
-        const setNotifications = useNotificationStore((state) => state.setNotifications);
 
         const postHog = usePostHog();
 

--- a/apps/antalmanac/src/components/RightPane/AddedCourses/Notifications/NotificationsTabs.tsx
+++ b/apps/antalmanac/src/components/RightPane/AddedCourses/Notifications/NotificationsTabs.tsx
@@ -4,6 +4,7 @@ import { NotificationAddOutlined } from '@mui/icons-material';
 import { TabContext, TabList, TabPanel } from '@mui/lab';
 import { Box, Tab, Paper, CircularProgress, Typography, useTheme } from '@mui/material';
 import { useMemo, useState } from 'react';
+import { useShallow } from 'zustand/react/shallow';
 
 function groupNotificationsByTerm(notifications: Partial<Record<string, Notification>>) {
     return Object.entries(notifications).reduce<Record<string, string[]>>((groups, [key, notification]) => {
@@ -22,8 +23,9 @@ function groupNotificationsByTerm(notifications: Partial<Record<string, Notifica
 
 export function NotificationsTabs() {
     const theme = useTheme();
-    const initialized = useNotificationStore((store) => store.initialized);
-    const notifications = useNotificationStore((store) => store.notifications);
+    const { initialized, notifications } = useNotificationStore(
+        useShallow((store) => ({ initialized: store.initialized, notifications: store.notifications }))
+    );
 
     const groups = useMemo(() => groupNotificationsByTerm(notifications), [notifications]);
     const sortedTerms = useMemo(() => Object.keys(groups).sort(), [groups]);

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/action-cell/ActionCell.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/action-cell/ActionCell.tsx
@@ -12,6 +12,7 @@ import { Visibility, VisibilityOff, VisibilityOutlined } from '@mui/icons-materi
 import { Box, CircularProgress, IconButton, Tooltip } from '@mui/material';
 import type { AASection, CourseDetails } from '@packages/antalmanac-types';
 import { memo, useCallback } from 'react';
+import { useShallow } from 'zustand/react/shallow';
 
 interface ActionCellProps {
     section: AASection;
@@ -25,9 +26,11 @@ interface ActionCellProps {
 export const ActionCell = memo(
     ({ section, term, courseDetails, scheduleConflict, addedCourse, scheduleNames }: ActionCellProps) => {
         const initialized = useNotificationStore((state) => state.initialized);
-        const cycleVisibility = useHiddenCoursesStore((state) => state.cycleVisibility);
-        const classVisibility = useHiddenCoursesStore((state) =>
-            state.getVisibility(AppStore.getCurrentScheduleId(), section.sectionCode)
+        const [cycleVisibility, classVisibility] = useHiddenCoursesStore(
+            useShallow((state) => [
+                state.cycleVisibility,
+                state.getVisibility(AppStore.getCurrentScheduleId(), section.sectionCode),
+            ])
         );
 
         const isMobile = useIsMobile();

--- a/apps/antalmanac/src/hooks/useQuickSearch.tsx
+++ b/apps/antalmanac/src/hooks/useQuickSearch.tsx
@@ -4,10 +4,12 @@ import { useCoursePaneStore } from '$stores/CoursePaneStore';
 import { useTabStore } from '$stores/TabStore';
 import { useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { useShallow } from 'zustand/react/shallow';
 
 export function useQuickSearch() {
-    const displaySections = useCoursePaneStore((s) => s.displaySections);
-    const forceUpdate = useCoursePaneStore((s) => s.forceUpdate);
+    const { displaySections, forceUpdate } = useCoursePaneStore(
+        useShallow((s) => ({ displaySections: s.displaySections, forceUpdate: s.forceUpdate }))
+    );
     const setActiveTab = useTabStore((s) => s.setActiveTab);
     const navigate = useNavigate();
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Continues the Zustand shallow comparison work from #1805 (`useShallow` from `zustand/react/shallow`).

## Summary

Merges multiple `use*Store` hooks on the same store into a single `useShallow` selector so components subscribe once per store and avoid extra re-renders when unrelated slice updates occur.

## Changes

- **ActionCell** — combine `cycleVisibility` + `getVisibility` from `useHiddenCoursesStore`
- **ReviewPrompt / ReviewStep / EnrollmentConfirmStep** — consolidate `useSessionStore` and `useReviewPromptStore` subscriptions
- **NotificationsTabs / NotificationTableRowCheckbox** — consolidate `useNotificationStore` subscriptions
- **useQuickSearch** — consolidate `useCoursePaneStore` (`displaySections`, `forceUpdate`)
- **AppThemeProvider** — consolidate `useThemeStore` (`isDark`, `setAppTheme`)

Store APIs are unchanged; selector-only refactors matching patterns in `SearchForm.tsx`, `SearchWithPlanner.tsx`, and `CalendarRoot.tsx`.

## Verification

- `pnpm lint` passes
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-89a2106e-79d5-4780-9009-6ca505c67345"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-89a2106e-79d5-4780-9009-6ca505c67345"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

