### PR TITLE
refactor: drop redundant useEffects in search, sign-in, and calendar popover

### DIFF
--- a/apps/antalmanac/src/components/Calendar/CourseCalendarEvent.tsx
+++ b/apps/antalmanac/src/components/Calendar/CourseCalendarEvent.tsx
@@ -15,7 +15,7 @@ import { Chip, IconButton, Paper, Tooltip, Button, Box } from '@mui/material';
 import { AATerm, CustomEventId } from '@packages/antalmanac-types';
 import { WebsocSectionFinalExam } from '@packages/anteater-api/types';
 import { usePostHog } from 'posthog-js/react';
-import { useEffect, useRef } from 'react';
+import { useRef } from 'react';
 import { Event } from 'react-big-calendar';
 
 interface CommonCalendarEvent extends Event {
@@ -95,20 +95,6 @@ export const CourseCalendarEvent = ({ selectedEvent, scheduleNames, closePopover
     const isMilitaryTime = useTimeFormatStore((store) => store.isMilitaryTime);
 
     const postHog = usePostHog();
-
-    useEffect(() => {
-        const handleKeyDown = (event: KeyboardEvent) => {
-            if (event.key === 'Escape') {
-                closePopover();
-            }
-        };
-
-        document.addEventListener('keydown', handleKeyDown);
-
-        return () => {
-            document.removeEventListener('keydown', handleKeyDown);
-        };
-    }, [closePopover]);
 
     if (!selectedEvent.isCustomEvent) {
         const { term, instructors, sectionCode, title, finalExam, locations, sectionType, deptValue, courseNumber } =

--- a/apps/antalmanac/src/components/Header/Signin.tsx
+++ b/apps/antalmanac/src/components/Header/Signin.tsx
@@ -32,7 +32,7 @@ import {
     TextField,
 } from '@mui/material';
 import { usePostHog } from 'posthog-js/react';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useState, type KeyboardEvent } from 'react';
 
 const ALERT_MESSAGES: Record<string, { title: string; severity: AlertColor }> = {
     SESSION_EXPIRED: {
@@ -132,49 +132,27 @@ export const Signin = () => {
         setLocalStorageFromLoading('true');
     };
 
-    const enterEvent = useCallback(
-        (event: KeyboardEvent) => {
-            if (!showLegacyLogin) return;
-
-            if (event.key === 'Enter') {
-                event.preventDefault();
-                setIsOpen(false);
-                document.removeEventListener('keydown', enterEvent, false);
-                void loadScheduleAndSetLoading(userID, rememberMe);
-                setUserID('');
-                return false;
-            }
-        },
-        [showLegacyLogin, loadScheduleAndSetLoading, userID, rememberMe]
-    );
-
     const handleClose = useCallback(
         (wasCancelled: boolean) => {
-            if (wasCancelled) {
-                setIsOpen(false);
-                document.removeEventListener('keydown', enterEvent, false);
-                setUserID('');
-            } else {
-                setIsOpen(false);
-                document.removeEventListener('keydown', enterEvent, false);
+            setIsOpen(false);
+            setUserID('');
+            if (!wasCancelled) {
                 void loadScheduleAndSetLoading(userID, rememberMe);
-                setUserID('');
             }
         },
-        [loadScheduleAndSetLoading, userID, rememberMe, enterEvent]
+        [loadScheduleAndSetLoading, userID, rememberMe]
     );
 
-    useEffect(() => {
-        if (isOpen) {
-            document.addEventListener('keydown', enterEvent, false);
-        } else {
-            document.removeEventListener('keydown', enterEvent, false);
-        }
-
-        return () => {
-            document.removeEventListener('keydown', enterEvent, false);
-        };
-    }, [isOpen, enterEvent]);
+    const handleDialogKeyDown = useCallback(
+        (event: KeyboardEvent) => {
+            if (!showLegacyLogin || event.key !== 'Enter') {
+                return;
+            }
+            event.preventDefault();
+            handleClose(false);
+        },
+        [showLegacyLogin, handleClose]
+    );
 
     useEffect(() => {
         const savedUserID = getLocalStorageUserId();
@@ -190,7 +168,7 @@ export const Signin = () => {
                 loading={loadingSchedule}
             />
 
-            <Dialog open={isOpen} onClose={() => handleClose(true)}>
+            <Dialog open={isOpen} onClose={() => handleClose(true)} onKeyDown={handleDialogKeyDown}>
                 <DialogContent>
                     <Stack spacing={1}>
                         <GoogleSignInButton onClick={() => handleLogin('google')} fullWidth />

--- a/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/DepartmentSearchBar/DepartmentSearchBar.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/DepartmentSearchBar/DepartmentSearchBar.tsx
@@ -60,15 +60,14 @@ export function DepartmentSearchBar() {
 
             if (newValue === 'ALL') return;
 
-            if (recentSearches.includes(newValue)) {
-                setRecentSearches((prev) =>
-                    prev.sort((a, b) => {
-                        return a === newValue ? -1 : b === newValue ? 1 : 0;
-                    })
-                );
-            } else {
-                setRecentSearches((prev) => [newValue, ...prev].slice(0, 5));
-            }
+            const nextRecentSearches = recentSearches.includes(newValue)
+                ? [...recentSearches].sort((a, b) => {
+                      return a === newValue ? -1 : b === newValue ? 1 : 0;
+                  })
+                : [newValue, ...recentSearches].slice(0, 5);
+
+            setRecentSearches(nextRecentSearches);
+            setLocalStorageRecentlySearched(JSON.stringify(nextRecentSearches));
         },
         [recentSearches, options]
     );
@@ -80,10 +79,6 @@ export function DepartmentSearchBar() {
             RightPaneStore.off('formReset', resetField);
         };
     }, [resetField]);
-
-    useEffect(() => {
-        setLocalStorageRecentlySearched(JSON.stringify(recentSearches));
-    }, [recentSearches]);
 
     return (
         <LabeledAutocomplete

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody/SectionTableBodyRow.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody/SectionTableBodyRow.tsx
@@ -82,18 +82,23 @@ export const SectionTableBodyRow = memo((props: SectionTableBodyRowProps) => {
         AppStore.getAddedSectionCodes().has(`${section.sectionCode} ${term.shortName}`)
     );
 
-    const [currColor, setCurrColor] = useState(() => getSectionScheduleColor(section, term));
+    const [colorOverride, setColorOverride] = useState<string | null>(null);
+    const [, bumpScheduleColor] = useState(0);
     const [colorPopoverAnchorEl, setColorPopoverAnchorEl] = useState<PopoverProps['anchorEl']>(null);
+
+    const scheduleColor = getSectionScheduleColor(section, term);
+    const currColor = colorOverride ?? scheduleColor;
 
     const updateHighlight = useCallback(() => {
         setAddedCourse(AppStore.getAddedSectionCodes().has(`${section.sectionCode} ${term.shortName}`));
     }, [section.sectionCode, term]);
 
     const updateColorFromSchedule = useCallback(() => {
-        setCurrColor(getSectionScheduleColor(section, term));
-    }, [section.sectionCode, section.color, term]);
+        setColorOverride(null);
+        bumpScheduleColor((n) => n + 1);
+    }, []);
     const updateColorFromPicker = useCallback((newColor: string) => {
-        setCurrColor(newColor);
+        setColorOverride(newColor);
     }, []);
 
     const handleMouseEnter = useCallback(() => {
@@ -118,7 +123,7 @@ export const SectionTableBodyRow = memo((props: SectionTableBodyRowProps) => {
 
     const handleColorChange = useCallback(
         (newColor: { hex: string }) => {
-            setCurrColor(newColor.hex);
+            setColorOverride(newColor.hex);
             changeCourseColor(section.sectionCode, term, newColor.hex);
         },
         [section.sectionCode, term]
@@ -134,10 +139,6 @@ export const SectionTableBodyRow = memo((props: SectionTableBodyRowProps) => {
             AppStore.removeListener('currentScheduleIndexChange', updateHighlight);
         };
     }, [updateHighlight]);
-
-    useEffect(() => {
-        setCurrColor(getSectionScheduleColor(section, term));
-    }, [section.sectionCode, section.color, term]);
 
     useEffect(() => {
         AppStore.on('addedCoursesChange', updateColorFromSchedule);

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody/SectionTableBodyRow.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody/SectionTableBodyRow.tsx
@@ -82,23 +82,18 @@ export const SectionTableBodyRow = memo((props: SectionTableBodyRowProps) => {
         AppStore.getAddedSectionCodes().has(`${section.sectionCode} ${term.shortName}`)
     );
 
-    const [colorOverride, setColorOverride] = useState<string | null>(null);
-    const [, bumpScheduleColor] = useState(0);
+    const [currColor, setCurrColor] = useState(() => getSectionScheduleColor(section, term));
     const [colorPopoverAnchorEl, setColorPopoverAnchorEl] = useState<PopoverProps['anchorEl']>(null);
-
-    const scheduleColor = getSectionScheduleColor(section, term);
-    const currColor = colorOverride ?? scheduleColor;
 
     const updateHighlight = useCallback(() => {
         setAddedCourse(AppStore.getAddedSectionCodes().has(`${section.sectionCode} ${term.shortName}`));
     }, [section.sectionCode, term]);
 
     const updateColorFromSchedule = useCallback(() => {
-        setColorOverride(null);
-        bumpScheduleColor((n) => n + 1);
-    }, []);
+        setCurrColor(getSectionScheduleColor(section, term));
+    }, [section.sectionCode, section.color, term]);
     const updateColorFromPicker = useCallback((newColor: string) => {
-        setColorOverride(newColor);
+        setCurrColor(newColor);
     }, []);
 
     const handleMouseEnter = useCallback(() => {
@@ -123,7 +118,7 @@ export const SectionTableBodyRow = memo((props: SectionTableBodyRowProps) => {
 
     const handleColorChange = useCallback(
         (newColor: { hex: string }) => {
-            setColorOverride(newColor.hex);
+            setCurrColor(newColor.hex);
             changeCourseColor(section.sectionCode, term, newColor.hex);
         },
         [section.sectionCode, term]
@@ -139,6 +134,10 @@ export const SectionTableBodyRow = memo((props: SectionTableBodyRowProps) => {
             AppStore.removeListener('currentScheduleIndexChange', updateHighlight);
         };
     }, [updateHighlight]);
+
+    useEffect(() => {
+        setCurrColor(getSectionScheduleColor(section, term));
+    }, [section.sectionCode, section.color, term]);
 
     useEffect(() => {
         AppStore.on('addedCoursesChange', updateColorFromSchedule);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Removes **3 redundant `useEffect` hooks** by handling the same behavior in event handlers or existing UI primitives.

### Department search recents
`DepartmentSearchBar` writes recent departments to `localStorage` inside `handleChange` when the list updates, instead of watching `recentSearches` in an effect.

### Sign-in dialog Enter key
`Signin` handles Enter for the legacy user ID field via `Dialog` `onKeyDown` while the dialog is open, instead of adding and removing a document-level `keydown` listener in an effect.

### Calendar event popover Escape
`CourseCalendarEvent` no longer registers a document Escape listener. The parent `CalendarEventPopover` MUI `Popover` already calls `onClose` when the user presses Escape.

## Test plan

- [ ] Department search: pick a department, reload — recents still persist
- [ ] Sign-in: expand legacy user ID, Enter submits; Cancel still works
- [ ] Calendar: open an event popover, Escape closes it

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-443b2491-a05c-4db0-9a70-1be5e86c57fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-443b2491-a05c-4db0-9a70-1be5e86c57fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

