### PR TITLE
Migrate feedback, unsubscribe, outage, and 404 routes to App Router

### DIFF
--- a/apps/antalmanac/src/App.tsx
+++ b/apps/antalmanac/src/App.tsx
@@ -6,10 +6,7 @@ import AppPostHogProvider from '$providers/PostHog';
 import AppQueryProvider from '$providers/Query';
 import { AuthPage } from '$routes/AuthPage';
 import { ErrorPage } from '$routes/ErrorPage';
-import Feedback from '$routes/Feedback';
 import Home from '$routes/Home';
-import { OutagePage } from '$routes/OutagePage';
-import { Unsubscribe } from '$routes/UnsubscribePage';
 import AppThemeProvider from '$src/app/Theme';
 import { AppRouterCacheProvider } from '@mui/material-nextjs/v15-appRouter';
 import { TourProvider } from '@reactour/tour';
@@ -43,18 +40,8 @@ const BROWSER_ROUTER = createBrowserRouter([
                 errorElement: <ErrorPage />,
             },
             {
-                path: '/unsubscribe/:userId',
-                element: <Unsubscribe />,
-                errorElement: <ErrorPage />,
-            },
-            {
                 path: '/:tab',
                 element: HOME_PAGE,
-                errorElement: <ErrorPage />,
-            },
-            {
-                path: '/feedback',
-                element: <Feedback />,
                 errorElement: <ErrorPage />,
             },
             {
@@ -75,10 +62,6 @@ const BROWSER_ROUTER = createBrowserRouter([
                 element: <AuthPage />,
                 errorElement: <ErrorPage />,
             },
-            {
-                path: '*',
-                element: <Navigate to="/" replace />,
-            },
         ],
     },
 ]);
@@ -87,11 +70,6 @@ const OUTAGE_ROUTER = createBrowserRouter([
     {
         element: <RouteLayout />,
         children: [
-            {
-                path: '/outage',
-                element: <OutagePage />,
-                errorElement: <ErrorPage />,
-            },
             {
                 path: '*',
                 element: <Navigate to="/outage" replace />,

--- a/apps/antalmanac/src/app/(standalone)/layout.tsx
+++ b/apps/antalmanac/src/app/(standalone)/layout.tsx
@@ -1,0 +1,5 @@
+import { StandaloneProviders } from '$components/standalone/StandaloneProviders';
+
+export default function StandaloneLayout({ children }: { children: React.ReactNode }) {
+    return <StandaloneProviders>{children}</StandaloneProviders>;
+}

--- a/apps/antalmanac/src/app/(standalone)/outage/page.tsx
+++ b/apps/antalmanac/src/app/(standalone)/outage/page.tsx
@@ -1,0 +1,5 @@
+import { OutagePage } from '$routes/OutagePage';
+
+export default function Outage() {
+    return <OutagePage />;
+}

--- a/apps/antalmanac/src/app/(standalone)/unsubscribe/[userId]/page.tsx
+++ b/apps/antalmanac/src/app/(standalone)/unsubscribe/[userId]/page.tsx
@@ -1,0 +1,10 @@
+import { Unsubscribe } from '$routes/UnsubscribePage';
+import { Suspense } from 'react';
+
+export default function UnsubscribePage() {
+    return (
+        <Suspense>
+            <Unsubscribe />
+        </Suspense>
+    );
+}

--- a/apps/antalmanac/src/app/[[...slug]]/page.tsx
+++ b/apps/antalmanac/src/app/[[...slug]]/page.tsx
@@ -1,11 +1,25 @@
 import { ClientOnly } from '$src/app/[[...slug]]/client';
 import { SeoContent } from '$src/app/[[...slug]]/seo-content';
+import { notFound } from 'next/navigation';
+
+/** Multi-segment paths still handled by the client SPA (react-router-dom). */
+const SPA_MULTI_SEGMENT_PATHS = new Set(['auth/native']);
 
 export function generateStaticParams() {
     return [{ slug: [] }, { slug: ['added'] }, { slug: ['map'] }];
 }
 
-export default function Page() {
+type PageProps = {
+    params: Promise<{ slug?: string[] }>;
+};
+
+export default async function Page({ params }: PageProps) {
+    const { slug = [] } = await params;
+
+    if (slug.length >= 2 && !SPA_MULTI_SEGMENT_PATHS.has(slug.join('/'))) {
+        notFound();
+    }
+
     return (
         <>
             <SeoContent />

--- a/apps/antalmanac/src/app/feedback/route.ts
+++ b/apps/antalmanac/src/app/feedback/route.ts
@@ -1,0 +1,6 @@
+import { FEEDBACK_LINK } from '$src/globals';
+import { NextResponse } from 'next/server';
+
+export function GET() {
+    return NextResponse.redirect(FEEDBACK_LINK, 308);
+}

--- a/apps/antalmanac/src/app/not-found.tsx
+++ b/apps/antalmanac/src/app/not-found.tsx
@@ -1,0 +1,10 @@
+import { NotFoundPage } from '$components/standalone/NotFoundPage';
+import { StandaloneProviders } from '$components/standalone/StandaloneProviders';
+
+export default function NotFound() {
+    return (
+        <StandaloneProviders>
+            <NotFoundPage />
+        </StandaloneProviders>
+    );
+}

--- a/apps/antalmanac/src/components/standalone/NotFoundPage.tsx
+++ b/apps/antalmanac/src/components/standalone/NotFoundPage.tsx
@@ -1,0 +1,57 @@
+'use client';
+
+import { ExpandMore } from '@mui/icons-material';
+import { Box, Accordion, AccordionDetails, AccordionSummary, Button, Stack, Typography } from '@mui/material';
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+
+export function NotFoundPage() {
+    const pathname = usePathname();
+
+    return (
+        <Box sx={{ height: '100dvh', overflowY: 'auto' }}>
+            <Stack
+                sx={{
+                    display: 'flex',
+                    justifyContent: 'center',
+                    textAlign: 'center',
+                    maxWidth: 800,
+                    minHeight: '100dvh',
+                    margin: 'auto',
+                    padding: 2,
+                    gap: 2,
+                }}
+            >
+                <Typography variant="h3" component="h1">
+                    Page not found
+                </Typography>
+                <Typography variant="h5" component="p">
+                    We couldn&apos;t find a page at <strong>{pathname}</strong>.
+                </Typography>
+                <Link href="/">
+                    <Button variant="contained" size="large">
+                        Back to Home
+                    </Button>
+                </Link>
+                <Accordion disableGutters sx={{ maxWidth: '100%' }}>
+                    <AccordionSummary expandIcon={<ExpandMore />}>
+                        <Typography component="p">Looking for something else?</Typography>
+                    </AccordionSummary>
+                    <AccordionDetails sx={{ textAlign: 'left' }}>
+                        <Typography>
+                            Try the{' '}
+                            <Link href="/" style={{ textDecoration: 'underline' }}>
+                                schedule planner
+                            </Link>{' '}
+                            or{' '}
+                            <Link href="/feedback" style={{ textDecoration: 'underline' }}>
+                                send feedback
+                            </Link>
+                            .
+                        </Typography>
+                    </AccordionDetails>
+                </Accordion>
+            </Stack>
+        </Box>
+    );
+}

--- a/apps/antalmanac/src/components/standalone/StandaloneProviders.tsx
+++ b/apps/antalmanac/src/components/standalone/StandaloneProviders.tsx
@@ -1,0 +1,21 @@
+'use client';
+
+import AppPostHogProvider from '$providers/PostHog';
+import AppQueryProvider from '$providers/Query';
+import AppThemeProvider from '$src/app/Theme';
+import { AppRouterCacheProvider } from '@mui/material-nextjs/v15-appRouter';
+
+/**
+ * Minimal provider stack for App Router pages outside the main SPA shell.
+ */
+export function StandaloneProviders({ children }: { children: React.ReactNode }) {
+    return (
+        <AppRouterCacheProvider options={{ enableCssLayer: true }}>
+            <AppThemeProvider>
+                <AppPostHogProvider>
+                    <AppQueryProvider>{children}</AppQueryProvider>
+                </AppPostHogProvider>
+            </AppThemeProvider>
+        </AppRouterCacheProvider>
+    );
+}

--- a/apps/antalmanac/src/routes/Feedback.tsx
+++ b/apps/antalmanac/src/routes/Feedback.tsx
@@ -1,6 +1,0 @@
-import { FEEDBACK_LINK } from '$src/globals';
-
-export default function Feedback() {
-    window.location.replace(FEEDBACK_LINK);
-    return null;
-}

--- a/apps/antalmanac/src/routes/OutagePage.tsx
+++ b/apps/antalmanac/src/routes/OutagePage.tsx
@@ -1,5 +1,7 @@
-import { Box, Typography, Stack } from '@mui/material';
-import { Link } from 'react-router-dom';
+'use client';
+
+import { Box, Stack, Typography } from '@mui/material';
+import Link from 'next/link';
 
 export const OutagePage = () => {
     return (
@@ -22,7 +24,11 @@ export const OutagePage = () => {
                 <Stack spacing={2}>
                     <Typography variant="h5" component="p" sx={{ textWrap: 'balance' }}>
                         We apologize for the inconvenience and are working to get AntAlmanac back on online. Check out
-                        the <Link to="https://discord.gg/KqJq8huuBB">ICSSC Projects server</Link> for updates.
+                        the{' '}
+                        <Link href="https://discord.gg/KqJq8huuBB" style={{ textDecoration: 'underline' }}>
+                            ICSSC Projects server
+                        </Link>{' '}
+                        for updates.
                     </Typography>
                 </Stack>
             </Stack>

--- a/apps/antalmanac/src/routes/UnsubscribePage.tsx
+++ b/apps/antalmanac/src/routes/UnsubscribePage.tsx
@@ -1,12 +1,15 @@
+'use client';
+
 import { trpcReact } from '$lib/api/trpc';
 import { parseQuarter } from '$lib/termHelpers';
 import { Box, Button } from '@mui/material';
+import { useParams, useSearchParams } from 'next/navigation';
 import { useState } from 'react';
-import { useParams, useSearchParams } from 'react-router-dom';
 
 export const Unsubscribe = () => {
-    const { userId } = useParams();
-    const [searchParams] = useSearchParams();
+    const params = useParams();
+    const userId = typeof params.userId === 'string' ? params.userId : params.userId?.[0];
+    const searchParams = useSearchParams();
 
     const sectionCode = searchParams.get('sectionCode');
     const searchParamQuarter = searchParams.get('quarter');


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Moves the first four React Router → App Router migrations off the client SPA shell:

1. **`/feedback`** — server `GET` handler returns a 308 redirect to the external Asana form (replaces client-side `window.location.replace`).
2. **`/unsubscribe/:userId`** — dedicated App Router page with `StandaloneProviders` (Theme, tRPC, React Query). Email links no longer download the full planner bundle.
3. **`/outage`** — static maintenance page under the same standalone layout.
4. **Unknown multi-segment paths** — `app/not-found.tsx` plus `notFound()` in the catch-all page for paths that are not `auth/native`. Removes the React Router `*` → `/` redirect for those URLs.

Also introduces `StandaloneProviders` for App Router pages outside the main SPA and updates `UnsubscribePage` / `OutagePage` to use `next/navigation`.

## Test Plan

- [ ] Visit `/feedback` — should 308 redirect to the Asana form
- [ ] Visit `/unsubscribe/<userId>?sectionCode=...&quarter=...&year=...` — confirm page loads without the main planner UI; unsubscribe still works
- [ ] Visit `/outage` — maintenance copy renders with themed MUI styles
- [ ] Visit `/does/not/exist` — 404 page (not redirected to `/`)
- [ ] Visit `/auth/native?...` — still loads SPA auth flow
- [ ] Visit `/`, `/added`, `/map`, `/auth` — planner SPA unchanged
- [ ] `pnpm lint` passes

## Notes

When `OUTAGE` is set to `true` in `App.tsx`, the SPA still redirects any shell load to `/outage`; the page itself is now served by Next.js.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-017a5105-cdc7-43f8-b242-f7c3c5e5c5ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-017a5105-cdc7-43f8-b242-f7c3c5e5c5ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

