### PR TITLE
fix: stable react keys

### DIFF
--- a/apps/antalmanac/src/components/Calendar/Toolbar/CustomEventDialog/ScheduleSelector.tsx
+++ b/apps/antalmanac/src/components/Calendar/Toolbar/CustomEventDialog/ScheduleSelector.tsx
@@ -32,7 +32,7 @@ export function ScheduleSelector({ scheduleIndices, onSelectScheduleIndices, sch
             >
                 {scheduleNames.map((name: string, index: number) => {
                     return (
-                        <MenuItem key={index} value={index}>
+                        <MenuItem key={`${name}-${index}`} value={index}>
                             {name}
                         </MenuItem>
                     );

--- a/apps/antalmanac/src/components/Header/Import.tsx
+++ b/apps/antalmanac/src/components/Header/Import.tsx
@@ -747,7 +747,7 @@ export function Import() {
                                         <Stack spacing={1}>
                                             {exportSchedules.map((schedule, index) => (
                                                 <Paper
-                                                    key={index}
+                                                    key={schedule.id ?? `${schedule.scheduleName}-${index}`}
                                                     sx={{
                                                         p: 1.5,
                                                         border: '2px solid',
@@ -1051,7 +1051,7 @@ export function Import() {
                                                 <Stack spacing={1}>
                                                     {importedSchedules.map((schedule, index) => (
                                                         <Paper
-                                                            key={index}
+                                                            key={schedule.id ?? `${schedule.scheduleName}-${index}`}
                                                             sx={{
                                                                 p: 1.5,
                                                                 border: '2px solid',

--- a/apps/antalmanac/src/components/RightPane/AddedCourses/FallbackSchedule.tsx
+++ b/apps/antalmanac/src/components/RightPane/AddedCourses/FallbackSchedule.tsx
@@ -49,9 +49,9 @@ export function FallbackSchedule() {
                 sectionsByTerm.map(([term, sections]) => (
                     <Box key={term}>
                         <Typography variant="h6">{term}</Typography>
-                        <Paper key={term} elevation={1}>
-                            {sections.map((section, index) => (
-                                <Tooltip title="Click to copy section code" placement="right" key={index}>
+                        <Paper elevation={1}>
+                            {sections.map((section) => (
+                                <Tooltip title="Click to copy section code" placement="right" key={section}>
                                     <Chip
                                         onClick={(event) => {
                                             clickToCopy(event, section);
@@ -63,7 +63,6 @@ export function FallbackSchedule() {
                                         label={section}
                                         size="small"
                                         style={{ margin: '10px 10px 10px 10px' }}
-                                        key={index}
                                     />
                                 </Tooltip>
                             ))}

--- a/apps/antalmanac/src/components/RightPane/CoursePane/CourseRenderPane.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/CourseRenderPane.tsx
@@ -83,6 +83,16 @@ function estimateCoursePaneLazyHeight(entry: CourseListEntry): number {
     return isCourseEntry(entry) ? entry.sections.length * 60 + 20 + 40 : 200;
 }
 
+function getCourseListEntryKey(entry: CourseListEntry): string {
+    if (isSchoolEntry(entry)) {
+        return `school-${entry.schoolName}`;
+    }
+    if (isDepartmentEntry(entry)) {
+        return `dept-${entry.deptCode}`;
+    }
+    return `course-${entry.deptCode}-${entry.courseNumber}`;
+}
+
 function cleanHeaders(items: CourseListEntry[]): CourseListEntry[] {
     const result: CourseListEntry[] = [];
     let pendingSchool: WebsocSchool | null = null;
@@ -445,7 +455,7 @@ export default function CourseRenderPane(props: { id?: number }) {
                         {courseData.map((data, index) => (
                             <LazyLoad
                                 once
-                                key={index}
+                                key={getCourseListEntryKey(data)}
                                 overflow
                                 height={estimateCoursePaneLazyHeight(data)}
                                 offset={1000}

--- a/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/SearchWithPlanner.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/SearchWithPlanner.tsx
@@ -20,7 +20,7 @@ import { OpenInBrowser } from '@mui/icons-material';
 import { Box, IconButton, MenuItem, Tooltip, Typography } from '@mui/material';
 import { Roadmap } from '@packages/antalmanac-types';
 import { useSearchParams } from 'next/navigation';
-import { ComponentProps, HTMLAttributes, useCallback, useEffect, useMemo, useState } from 'react';
+import { ComponentProps, HTMLAttributes, type Key, useCallback, useEffect, useMemo, useState } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 
 interface SearchWithPlannerProps {
@@ -139,18 +139,20 @@ export const SearchWithPlanner = ({ labelProps }: SearchWithPlannerProps) => {
         );
     };
 
-    const renderOption = (props: HTMLAttributes<HTMLLIElement>, roadmap: Roadmap) => {
-        const menuItem = (
+    const renderOption = (props: HTMLAttributes<HTMLLIElement> & { key: Key }, roadmap: Roadmap) => {
+        const { key, ...restProps } = props;
+
+        const option = (
             <Box
-                key={roadmap.id}
+                component="li"
+                key={key}
+                {...restProps}
                 display="flex"
                 alignItems="center"
                 justifyContent="space-between"
                 sx={{ paddingRight: 1 }}
             >
                 <MenuItem
-                    {...props}
-                    key={roadmap.id}
                     onClick={() => search(roadmap.id)}
                     disabled={!doesRoadmapIncludeTerm(roadmap.id)}
                     sx={{ width: '100%' }}
@@ -170,14 +172,15 @@ export const SearchWithPlanner = ({ labelProps }: SearchWithPlannerProps) => {
                 </Tooltip>
             </Box>
         );
+
         if (termRoadmapGrouping[RoadmapTermRelation.NoCourses].has(roadmap.id.toString())) {
             return (
-                <Tooltip key={roadmap.id} title="This roadmap has no courses for this term">
-                    <span>{menuItem}</span>
+                <Tooltip title="This roadmap has no courses for this term">
+                    <span>{option}</span>
                 </Tooltip>
             );
         }
-        return menuItem;
+        return option;
     };
 
     useEffect(() => {

--- a/apps/antalmanac/src/components/RightPane/SectionTable/PrereqTree.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/PrereqTree.tsx
@@ -38,8 +38,20 @@ const Node: FC<NodeProps> = (props) => {
 interface TreeProps {
     prerequisiteNames: string[];
     prerequisite: PrerequisiteNode;
-    key?: string;
     index?: number;
+}
+
+function getPrereqNodeKey(node: PrerequisiteNode, index: number): string {
+    if (Object.prototype.hasOwnProperty.call(node, 'prereqType')) {
+        const prereq = node as Prerequisite;
+        if (prereq.prereqType === 'course') {
+            return `course-${prereq.courseId}`;
+        }
+        return `exam-${prereq.examName}-${index}`;
+    }
+
+    const subtreeType = Object.keys(node)[0];
+    return `group-${subtreeType}-${index}`;
 }
 
 const PrereqTreeNode: FC<TreeProps> = (props) => {
@@ -49,7 +61,7 @@ const PrereqTreeNode: FC<TreeProps> = (props) => {
     if (isValueNode) {
         const prereq = prerequisite as Prerequisite;
         return (
-            <li key={props.index} className={'prerequisite-node'}>
+            <li className={'prerequisite-node'}>
                 <Node
                     label={
                         prereq.prereqType === 'course'
@@ -80,7 +92,7 @@ const PrereqTreeNode: FC<TreeProps> = (props) => {
                         <ul className="prereq-list">
                             {prereqTree[Object.keys(prerequisite)[0]].map((child, index) => (
                                 <PrereqTreeNode
-                                    key={`tree-${index}`}
+                                    key={getPrereqNodeKey(child, index)}
                                     prerequisiteNames={props.prerequisiteNames}
                                     index={index}
                                     prerequisite={child}
@@ -151,8 +163,8 @@ const PrereqTree: FC<PrereqProps> = (props) => {
                                 <>
                                     <ul style={{ padding: '0', display: 'flex' }}>
                                         <div className={'dependency-list-branch'}>
-                                            {Object.values(props.prerequisite_for).map((dependency, index) => (
-                                                <li key={`dependencyNode-${index}`} className={'dependency-node'}>
+                                            {Object.values(props.prerequisite_for).map((dependency) => (
+                                                <li key={dependency} className={'dependency-node'}>
                                                     <Node label={dependency} node={'dependencyNode'} />
                                                 </li>
                                             ))}

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/DayAndTimeCell.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/DayAndTimeCell.tsx
@@ -9,7 +9,11 @@ interface DayAndTimeCellProps {
 }
 
 function getMeetingKey(meeting: WebsocSectionMeeting, meetingIndex: number): string {
-    return `${meetingIndex}-${meeting.days}-${meeting.startTime ?? 'tba'}-${meeting.endTime ?? 'tba'}-${meeting.bldg.join(',')}`;
+    if (meeting.timeIsTBA) {
+        return `${meetingIndex}-tba`;
+    }
+
+    return `${meetingIndex}-${meeting.days}-${meeting.startTime.hour}:${meeting.startTime.minute}-${meeting.endTime.hour}:${meeting.endTime.minute}-${meeting.bldg.join(',')}`;
 }
 
 export const DayAndTimeCell = ({ meetings }: DayAndTimeCellProps) => {

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/DayAndTimeCell.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/DayAndTimeCell.tsx
@@ -8,21 +8,29 @@ interface DayAndTimeCellProps {
     meetings: WebsocSectionMeeting[];
 }
 
+function getMeetingKey(meeting: WebsocSectionMeeting, meetingIndex: number): string {
+    return `${meetingIndex}-${meeting.days}-${meeting.startTime ?? 'tba'}-${meeting.endTime ?? 'tba'}-${meeting.bldg.join(',')}`;
+}
+
 export const DayAndTimeCell = ({ meetings }: DayAndTimeCellProps) => {
     const isMilitaryTime = useTimeFormatStore((store) => store.isMilitaryTime);
 
     return (
         <TableBodyCellContainer>
-            {meetings.map((meeting) => {
+            {meetings.map((meeting, meetingIndex) => {
+                const key = getMeetingKey(meeting, meetingIndex);
+
                 if (meeting.timeIsTBA) {
-                    return <Box key={meeting.timeIsTBA.toString()}>TBA</Box>;
+                    return <Box key={key}>TBA</Box>;
                 }
 
                 if (meeting.startTime && meeting.endTime) {
                     const timeString = formatTimes(meeting.startTime, meeting.endTime, isMilitaryTime);
 
-                    return <Box key={meeting.timeIsTBA + meeting.bldg[0]}>{`${meeting.days} ${timeString}`}</Box>;
+                    return <Box key={key}>{`${meeting.days} ${timeString}`}</Box>;
                 }
+
+                return null;
             })}
         </TableBodyCellContainer>
     );

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/InstructorsCell.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/InstructorsCell.tsx
@@ -16,7 +16,7 @@ export const InstructorsCell = ({ instructors, sx }: InstructorsCellProps) => {
 
         const lastName = profName.substring(0, profName.indexOf(','));
         return (
-            <Box key={profName}>
+            <Box key={`${profName}-${index}`}>
                 <Typography
                     variant="body2"
                     sx={{

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/LocationsCell.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/LocationsCell.tsx
@@ -13,21 +13,21 @@ interface LocationsCellProps {
 export const LocationsCell = ({ meetings }: LocationsCellProps) => {
     return (
         <TableBodyCellContainer>
-            {meetings.map((meeting) => {
-                return !meeting.timeIsTBA ? (
-                    meeting.bldg.map((bldg) => {
-                        const [buildingName = ''] = bldg.split(' ');
-                        const buildingId = locationIds[buildingName];
-                        return (
-                            <Fragment key={meeting.timeIsTBA + bldg}>
-                                <MapLink buildingId={buildingId} room={bldg} />
-                                <br />
-                            </Fragment>
-                        );
-                    })
-                ) : (
-                    <Box>{'TBA'}</Box>
-                );
+            {meetings.flatMap((meeting, meetingIndex) => {
+                if (meeting.timeIsTBA) {
+                    return <Box key={`${meetingIndex}-tba`}>TBA</Box>;
+                }
+
+                return meeting.bldg.map((bldg, bldgIndex) => {
+                    const [buildingName = ''] = bldg.split(' ');
+                    const buildingId = locationIds[buildingName];
+                    return (
+                        <Fragment key={`${meetingIndex}-${bldgIndex}-${bldg}`}>
+                            <MapLink buildingId={buildingId} room={bldg} />
+                            <br />
+                        </Fragment>
+                    );
+                });
             })}
         </TableBodyCellContainer>
     );

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/RestrictionsCell.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/RestrictionsCell.tsx
@@ -16,10 +16,10 @@ export const RestrictionsCell = ({ restrictions }: RestrictionsCellProps) => {
 
     const parsedRestrictions = useMemo(
         () =>
-            restrictions.split(' ').map((code, index) => {
+            restrictions.split(' ').map((code) => {
                 if (code !== 'and' && code !== 'or') {
                     return (
-                        <Fragment key={index}>
+                        <Fragment key={code}>
                             {restrictionsMapping[code as keyof typeof restrictionsMapping]}
                             <br />
                         </Fragment>

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/action-cell/SectionActionMenu.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/action-cell/SectionActionMenu.tsx
@@ -70,7 +70,7 @@ export const SectionActionMenu = memo(function SectionActionMenu({
                 transformOrigin={{ vertical: 'top', horizontal: 'left' }}
             >
                 {scheduleNames.map((name, index) => (
-                    <MenuItem key={index} onClick={() => handleAddToSchedule(index)}>
+                    <MenuItem key={`${name}-${index}`} onClick={() => handleAddToSchedule(index)}>
                         Add to {name}
                     </MenuItem>
                 ))}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes incorrect or unstable React `key` usage across list-rendered UI in the section table, course pane, import dialog, and planner search autocomplete.

## Changes

- **DayAndTimeCell / LocationsCell**: Use per-meeting keys derived from index + meeting fields; add missing keys for TBA rows; flatten location lists with unique keys across meetings.
- **InstructorsCell**: Use `${profName}-${index}` for all instructor entries.
- **SearchWithPlanner**: Apply MUI Autocomplete pattern (`props.key` on outer `li`) matching `FuzzySearch`.
- **CourseRenderPane**: Stable keys per list entry type (`school-`, `dept-`, `course-`) instead of array index.
- **Import / FallbackSchedule**: Use schedule id or section code instead of index.
- **SectionActionMenu / ScheduleSelector**: `${name}-${index}` when schedule names may repeat.
- **PrereqTree / RestrictionsCell**: Stable keys from course ids, dependency ids, and restriction codes.

## Test Plan

- [ ] Open a course with multiple TBA meetings or multiple buildings — section table day/time and location cells render without console key warnings.
- [ ] Toggle "filter taken courses" on search results — school/dept/course headers keep correct content.
- [ ] Planner roadmap autocomplete — keyboard navigation and selection still work.
- [ ] Import/export schedule dialog — selecting schedules still works after reorder.

## Why

Duplicate or index-based keys caused React reconciliation issues when meetings shared TBA status, buildings overlapped, or course search results were filtered/reordered.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d9dd790a-ea24-4f71-92a6-2b32e6ac9d60"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d9dd790a-ea24-4f71-92a6-2b32e6ac9d60"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

