### PR TITLE
refactor: dialogs do not need sync to schedule

### DIFF
--- a/apps/antalmanac/src/components/dialogs/AddSchedule.tsx
+++ b/apps/antalmanac/src/components/dialogs/AddSchedule.tsx
@@ -1,6 +1,6 @@
 import { Box, Button, Dialog, DialogActions, DialogContent, DialogTitle, TextField } from '@mui/material';
 import type { DialogProps } from '@mui/material';
-import { useState, useEffect, useCallback } from 'react';
+import { useState } from 'react';
 
 import { addSchedule } from '$actions/AppStoreActions';
 import AppStore from '$stores/AppStore';
@@ -43,17 +43,6 @@ function AddScheduleDialog({ onClose, onKeyDown, ...props }: DialogProps) {
             }
         }
     };
-
-    const handleScheduleNamesChange = useCallback(() => {
-        setName(AppStore.getNextScheduleName(AppStore.getScheduleNames().length, AppStore.getDefaultScheduleName()));
-    }, []);
-
-    useEffect(() => {
-        AppStore.on('scheduleNamesChange', handleScheduleNamesChange);
-        return () => {
-            AppStore.off('scheduleNamesChange', handleScheduleNamesChange);
-        };
-    }, [handleScheduleNamesChange]);
 
     return (
         <Dialog onKeyDown={handleKeyDown} {...props}>

--- a/apps/antalmanac/src/components/dialogs/CopySchedule.tsx
+++ b/apps/antalmanac/src/components/dialogs/CopySchedule.tsx
@@ -11,7 +11,7 @@ import {
     type DialogProps,
 } from '@mui/material';
 import { usePostHog } from 'posthog-js/react';
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useCallback } from 'react';
 
 interface CopyScheduleDialogProps extends DialogProps {
     index: number;
@@ -36,17 +36,6 @@ function CopyScheduleDialog(props: CopyScheduleDialogProps) {
         copySchedule(index, name, undefined, postHog);
         onClose?.({}, 'escapeKeyDown');
     }, [index, name, onClose, postHog]);
-
-    const handleScheduleNamesChange = useCallback(() => {
-        setName(`Copy of ${AppStore.getScheduleNames()[index]}`);
-    }, [index]);
-
-    useEffect(() => {
-        AppStore.on('scheduleNamesChange', handleScheduleNamesChange);
-        return () => {
-            AppStore.off('scheduleNamesChange', handleScheduleNamesChange);
-        };
-    }, [handleScheduleNamesChange]);
 
     return (
         <Dialog onClose={onClose} {...props}>

--- a/apps/antalmanac/src/components/dialogs/DeleteSchedule.tsx
+++ b/apps/antalmanac/src/components/dialogs/DeleteSchedule.tsx
@@ -31,7 +31,7 @@ function DeleteScheduleDialog(props: ScheduleNameDialogProps) {
      * This is destructured separately for memoization.
      */
     const { onClose } = props;
-    const [name, setName] = useState<string>(AppStore.getScheduleNames()[index]);
+    const [name] = useState<string>(AppStore.getScheduleNames()[index]);
 
     const handleCancel = useCallback(() => {
         onClose?.({}, 'escapeKeyDown');

--- a/apps/antalmanac/src/components/dialogs/DeleteSchedule.tsx
+++ b/apps/antalmanac/src/components/dialogs/DeleteSchedule.tsx
@@ -9,7 +9,7 @@ import {
     DialogTitle,
     type DialogProps,
 } from '@mui/material';
-import { useCallback, useState } from 'react';
+import { useCallback } from 'react';
 
 interface ScheduleNameDialogProps extends DialogProps {
     /**
@@ -31,7 +31,7 @@ function DeleteScheduleDialog(props: ScheduleNameDialogProps) {
      * This is destructured separately for memoization.
      */
     const { onClose } = props;
-    const [name] = useState<string>(AppStore.getScheduleNames()[index]);
+    const name = AppStore.getScheduleNames()[index];
 
     const handleCancel = useCallback(() => {
         onClose?.({}, 'escapeKeyDown');

--- a/apps/antalmanac/src/components/dialogs/DeleteSchedule.tsx
+++ b/apps/antalmanac/src/components/dialogs/DeleteSchedule.tsx
@@ -9,7 +9,7 @@ import {
     DialogTitle,
     type DialogProps,
 } from '@mui/material';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useState } from 'react';
 
 interface ScheduleNameDialogProps extends DialogProps {
     /**
@@ -41,17 +41,6 @@ function DeleteScheduleDialog(props: ScheduleNameDialogProps) {
         deleteSchedule(index);
         onClose?.({}, 'escapeKeyDown');
     }, [index, onClose]);
-
-    const handleScheduleNamesChange = useCallback(() => {
-        setName(AppStore.getScheduleNames()[index]);
-    }, [index]);
-
-    useEffect(() => {
-        AppStore.on('scheduleNamesChange', handleScheduleNamesChange);
-        return () => {
-            AppStore.off('scheduleNamesChange', handleScheduleNamesChange);
-        };
-    }, [handleScheduleNamesChange]);
 
     return (
         <Dialog {...dialogProps}>

--- a/apps/antalmanac/src/components/dialogs/RenameSchedule.tsx
+++ b/apps/antalmanac/src/components/dialogs/RenameSchedule.tsx
@@ -10,7 +10,7 @@ import {
     TextField,
     type DialogProps,
 } from '@mui/material';
-import { useCallback, useState, useEffect } from 'react';
+import { useCallback, useState } from 'react';
 
 interface ScheduleNameDialogProps extends DialogProps {
     /**
@@ -64,18 +64,6 @@ function RenameScheduleDialog(props: ScheduleNameDialogProps) {
         },
         [onClose, submitName, onKeyDown]
     );
-
-    const handleScheduleNamesChange = useCallback(() => {
-        setName(AppStore.getScheduleNames()[index]);
-    }, [index]);
-
-    useEffect(() => {
-        AppStore.on('scheduleNamesChange', handleScheduleNamesChange);
-
-        return () => {
-            AppStore.off('scheduleNamesChange', handleScheduleNamesChange);
-        };
-    }, [handleScheduleNamesChange]);
 
     return (
         <Dialog onKeyDown={handleKeyDown} {...dialogProps}>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Remove `useEffect`-based `scheduleNamesChange` subscriptions from the four schedule dialogs. Each dialog now keeps its local name value as a mount-time snapshot from AppStore instead of continuously resyncing while the user may be editing.

Affected dialogs:
- `AddSchedule.tsx`
- `CopySchedule.tsx`
- `DeleteSchedule.tsx`
- `RenameSchedule.tsx`

## Test Plan

- [ ] Open Add Schedule dialog and verify default name is populated
- [ ] Open Copy/Rename/Delete dialogs and verify the schedule name is shown correctly
- [ ] Edit a name, press Enter to submit, and confirm the action completes
- [ ] Press Escape or Cancel to close without submitting
- [ ] Confirm submit buttons stay disabled when the name field is empty/whitespace

## Issues

Closes #
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-40372f20-f159-4c68-918f-da3280157d81"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-40372f20-f159-4c68-918f-da3280157d81"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

