### PR TITLE
refactor: remove duplicated scheduleNames state from CalendarEventPopover

### DIFF
--- a/apps/antalmanac/src/components/Calendar/CalendarEventPopover.tsx
+++ b/apps/antalmanac/src/components/Calendar/CalendarEventPopover.tsx
@@ -1,34 +1,23 @@
 'use client';
 
 import { CourseCalendarEvent, isSkeletonEvent } from '$components/Calendar/CourseCalendarEvent';
-import AppStore from '$stores/AppStore';
 import { useSelectedEventStore } from '$stores/SelectedEventStore';
 import { Popover } from '@mui/material';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 
-export function CalendarEventPopover() {
+interface CalendarEventPopoverProps {
+    scheduleNames: string[];
+}
+
+export function CalendarEventPopover({ scheduleNames }: CalendarEventPopoverProps) {
     const [anchorEl, selectedEvent, setSelectedEvent] = useSelectedEventStore(
         useShallow((state) => [state.selectedEventAnchorEl, state.selectedEvent, state.setSelectedEvent])
     );
 
-    const [scheduleNames, setScheduleNames] = useState(() => AppStore.getScheduleNames());
-
     const handleClosePopover = useCallback(() => {
         setSelectedEvent(null, null);
     }, [setSelectedEvent]);
-
-    useEffect(() => {
-        const updateScheduleNames = () => {
-            setScheduleNames(AppStore.getScheduleNames());
-        };
-
-        AppStore.on('scheduleNamesChange', updateScheduleNames);
-
-        return () => {
-            AppStore.off('scheduleNamesChange', updateScheduleNames);
-        };
-    }, []);
 
     if (!selectedEvent || isSkeletonEvent(selectedEvent)) {
         return null;

--- a/apps/antalmanac/src/components/Calendar/CalendarRoot.tsx
+++ b/apps/antalmanac/src/components/Calendar/CalendarRoot.tsx
@@ -397,7 +397,7 @@ export const ScheduleCalendar = memo(() => {
 
             <Box id="screenshot" height="0" flexGrow={1} position="relative">
                 <TbaCalendarCard />
-                <CalendarEventPopover />
+                <CalendarEventPopover scheduleNames={scheduleNames} />
 
                 <Backdrop
                     open={showEmptyState}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`ScheduleCalendar` in `CalendarRoot.tsx` already owns `scheduleNames` state and subscribes to `AppStore` `scheduleNamesChange` to keep it in sync. `CalendarEventPopover` duplicated that same state and subscription.

This change removes the redundant local state and effect from `CalendarEventPopover` and passes `scheduleNames` down from `CalendarRoot` as a prop, matching how `CalendarToolbar` already receives it.

**Data flow after refactor:**
`AppStore` → `ScheduleCalendar` (`scheduleNames` state via `scheduleNamesChange`) → `CalendarToolbar` / `CalendarEventPopover` → `CourseCalendarEvent`

## Test Plan

- [ ] Open the calendar with multiple schedules
- [ ] Click a course event to open the popover and confirm schedule names render correctly
- [ ] Rename or add a schedule while the popover is open and confirm names update in both the toolbar and popover

## Issues

Closes #

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7b106cfb-ef08-4f95-a707-89f9132b22e1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7b106cfb-ef08-4f95-a707-89f9132b22e1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

