### PR TITLE
refactor: consolidate SectionTableBodyRow store sync effects

### DIFF
--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody/SectionTableBodyRow.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody/SectionTableBodyRow.tsx
@@ -85,13 +85,6 @@ export const SectionTableBodyRow = memo((props: SectionTableBodyRowProps) => {
     const [currColor, setCurrColor] = useState(() => getSectionScheduleColor(section, term));
     const [colorPopoverAnchorEl, setColorPopoverAnchorEl] = useState<PopoverProps['anchorEl']>(null);
 
-    const updateHighlight = useCallback(() => {
-        setAddedCourse(AppStore.getAddedSectionCodes().has(`${section.sectionCode} ${term.shortName}`));
-    }, [section.sectionCode, term]);
-
-    const updateColorFromSchedule = useCallback(() => {
-        setCurrColor(getSectionScheduleColor(section, term));
-    }, [section.sectionCode, section.color, term]);
     const updateColorFromPicker = useCallback((newColor: string) => {
         setCurrColor(newColor);
     }, []);
@@ -124,32 +117,32 @@ export const SectionTableBodyRow = memo((props: SectionTableBodyRowProps) => {
         [section.sectionCode, term]
     );
 
-    // Attach event listeners to the store.
     useEffect(() => {
-        AppStore.on('addedCoursesChange', updateHighlight);
-        AppStore.on('currentScheduleIndexChange', updateHighlight);
+        const sectionKey = `${section.sectionCode} ${term.shortName}`;
+
+        const syncAddedCourse = () => {
+            setAddedCourse(AppStore.getAddedSectionCodes().has(sectionKey));
+        };
+        const syncColor = () => {
+            setCurrColor(getSectionScheduleColor(section, term));
+        };
+        const syncFromScheduleChanges = () => {
+            syncAddedCourse();
+            syncColor();
+        };
+
+        syncFromScheduleChanges();
+
+        AppStore.on('addedCoursesChange', syncFromScheduleChanges);
+        AppStore.on('currentScheduleIndexChange', syncFromScheduleChanges);
+        AppStore.on('colorChange', syncColor);
 
         return () => {
-            AppStore.removeListener('addedCoursesChange', updateHighlight);
-            AppStore.removeListener('currentScheduleIndexChange', updateHighlight);
+            AppStore.removeListener('addedCoursesChange', syncFromScheduleChanges);
+            AppStore.removeListener('currentScheduleIndexChange', syncFromScheduleChanges);
+            AppStore.removeListener('colorChange', syncColor);
         };
-    }, [updateHighlight]);
-
-    useEffect(() => {
-        setCurrColor(getSectionScheduleColor(section, term));
     }, [section.sectionCode, section.color, term]);
-
-    useEffect(() => {
-        AppStore.on('addedCoursesChange', updateColorFromSchedule);
-        AppStore.on('colorChange', updateColorFromSchedule);
-        AppStore.on('currentScheduleIndexChange', updateColorFromSchedule);
-
-        return () => {
-            AppStore.removeListener('addedCoursesChange', updateColorFromSchedule);
-            AppStore.removeListener('colorChange', updateColorFromSchedule);
-            AppStore.removeListener('currentScheduleIndexChange', updateColorFromSchedule);
-        };
-    }, [updateColorFromSchedule]);
 
     useEffect(() => {
         if (!addedCourse) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Consolidates redundant `useEffect` logic in `SectionTableBodyRow` that was synchronizing `addedCourse` and `currColor` from AppStore and props.

**Removed / merged:**
- Separate `addedCoursesChange` / `currentScheduleIndexChange` subscription for `addedCourse` (`updateHighlight`)
- Prop-to-state color reset effect (`setCurrColor(getSectionScheduleColor(...))` on `[section.sectionCode, section.color, term]`)
- Separate color subscription effect (`updateColorFromSchedule` on the same store events plus `colorChange`)

These are now a single store sync effect that:
1. Syncs both `addedCourse` and `currColor` immediately when section/term deps change (replacing the prop-to-state effect)
2. Subscribes to `addedCoursesChange` and `currentScheduleIndexChange` to update both states
3. Subscribes to `colorChange` to update only `currColor` (color-only changes do not affect added-course highlighting)

**Intentionally kept:**
- Color picker registration effect — registers/unregisters `updateColorFromPicker` when `addedCourse` becomes true/false, so external pickers (e.g. calendar `ColorPicker`) can push color updates into this row
- Local `handleColorChange` optimistic update for the row's own SketchPicker

## Test Plan

- [ ] Add a section to the schedule — row highlights and color strip appears with schedule color
- [ ] Remove a section — highlight and color strip hide
- [ ] Switch schedules — added-course highlighting and colors update for the active schedule
- [ ] Change section color via row color strip — color updates locally and in calendar
- [ ] Change section color via calendar color picker — row color strip updates
- [ ] Hover preview on unadded sections still works; added sections do not trigger hover preview
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d285cb80-0694-4fb6-8d55-f394154e7b9c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d285cb80-0694-4fb6-8d55-f394154e7b9c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

