### PR TITLE
Refactor fallback pane to reduce AppStore effect mirroring

### DIFF
--- a/apps/antalmanac/src/components/RightPane/AddedCourses/CustomEventsBox.tsx
+++ b/apps/antalmanac/src/components/RightPane/AddedCourses/CustomEventsBox.tsx
@@ -1,46 +1,27 @@
 import { CustomEventDetailView } from '$components/RightPane/AddedCourses/CustomEventDetailView';
+import { useCurrentCustomEvents } from '$hooks/useAppStoreSchedule';
 import AppStore from '$stores/AppStore';
-import { useFallbackStore } from '$stores/FallbackStore';
 import { Box, Typography } from '@mui/material';
 import type { RepeatingCustomEvent } from '@packages/antalmanac-types';
-import { useEffect, useState } from 'react';
-import { useShallow } from 'zustand/react/shallow';
 
-export function CustomEventsBox() {
-    const { fallbackMode, getCurrentFallbackSchedule } = useFallbackStore(
-        useShallow((store) => ({
-            fallbackMode: store.fallbackMode,
-            getCurrentFallbackSchedule: store.getCurrentFallbackSchedule,
-        }))
-    );
-    const currentScheduleIndex = AppStore.getCurrentScheduleIndex();
+type CustomEventsBoxProps = {
+    customEvents?: RepeatingCustomEvent[];
+};
 
-    const [customEvents, setCustomEvents] = useState<RepeatingCustomEvent[]>(
-        fallbackMode
-            ? getCurrentFallbackSchedule(currentScheduleIndex).customEvents
-            : AppStore.schedule.getCurrentCustomEvents()
-    );
+export function CustomEventsBox({ customEvents: customEventsProp }: CustomEventsBoxProps) {
+    if (customEventsProp !== undefined) {
+        return <CustomEventsBoxContent customEvents={customEventsProp} />;
+    }
 
-    useEffect(() => {
-        const handleCustomEventsChange = () => {
-            const { fallbackMode, getCurrentFallbackSchedule } = useFallbackStore.getState();
-            if (fallbackMode) {
-                const idx = AppStore.getCurrentScheduleIndex();
-                setCustomEvents([...getCurrentFallbackSchedule(idx).customEvents]);
-            } else {
-                setCustomEvents([...AppStore.schedule.getCurrentCustomEvents()]);
-            }
-        };
+    return <CustomEventsBoxFromStore />;
+}
 
-        AppStore.on('customEventsChange', handleCustomEventsChange);
-        AppStore.on('currentScheduleIndexChange', handleCustomEventsChange);
+function CustomEventsBoxFromStore() {
+    const customEvents = useCurrentCustomEvents();
+    return <CustomEventsBoxContent customEvents={customEvents} />;
+}
 
-        return () => {
-            AppStore.off('customEventsChange', handleCustomEventsChange);
-            AppStore.off('currentScheduleIndexChange', handleCustomEventsChange);
-        };
-    }, []);
-
+function CustomEventsBoxContent({ customEvents }: { customEvents: RepeatingCustomEvent[] }) {
     if (customEvents.length <= 0) {
         return null;
     }

--- a/apps/antalmanac/src/components/RightPane/AddedCourses/FallbackSchedule.tsx
+++ b/apps/antalmanac/src/components/RightPane/AddedCourses/FallbackSchedule.tsx
@@ -1,32 +1,20 @@
 import { CustomEventsBox } from '$components/RightPane/AddedCourses/CustomEventsBox';
 import { ScheduleNoteBox } from '$components/RightPane/AddedCourses/ScheduleNoteBox';
+import { useAppStoreScheduleIndex } from '$hooks/useAppStoreSchedule';
 import analyticsEnum, { logAnalytics } from '$lib/analytics/analytics';
 import { clickToCopy } from '$lib/helpers';
-import AppStore from '$stores/AppStore';
 import { useFallbackStore } from '$stores/FallbackStore';
 import { Box, Chip, Paper, Tooltip, Typography } from '@mui/material';
 import { ShortCourse } from '@packages/antalmanac-types';
 import { usePostHog } from 'posthog-js/react';
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo } from 'react';
 
 export function FallbackSchedule() {
+    const scheduleIndex = useAppStoreScheduleIndex();
     const getCurrentFallbackSchedule = useFallbackStore((store) => store.getCurrentFallbackSchedule);
-    const [currentScheduleIndex, setCurrentScheduleIndex] = useState(AppStore.getCurrentScheduleIndex());
     const postHog = usePostHog();
 
-    useEffect(() => {
-        const handleScheduleIndexChange = () => {
-            setCurrentScheduleIndex(AppStore.getCurrentScheduleIndex());
-        };
-
-        AppStore.on('currentScheduleIndexChange', handleScheduleIndexChange);
-
-        return () => {
-            AppStore.off('currentScheduleIndexChange', handleScheduleIndexChange);
-        };
-    }, []);
-
-    const fallbackSchedule = getCurrentFallbackSchedule(currentScheduleIndex);
+    const fallbackSchedule = getCurrentFallbackSchedule(scheduleIndex);
 
     const sectionsByTerm: [string, string[]][] = useMemo(() => {
         const result = fallbackSchedule.courses.reduce(
@@ -72,9 +60,9 @@ export function FallbackSchedule() {
                 ))
             }
 
-            <CustomEventsBox />
+            <CustomEventsBox customEvents={fallbackSchedule.customEvents} />
 
-            <ScheduleNoteBox />
+            <ScheduleNoteBox scheduleNote={fallbackSchedule.scheduleNote} />
 
             <Typography variant="body1">
                 Anteater API is currently unreachable. This is the information that we can currently retrieve.

--- a/apps/antalmanac/src/components/RightPane/AddedCourses/ScheduleNoteBox.tsx
+++ b/apps/antalmanac/src/components/RightPane/AddedCourses/ScheduleNoteBox.tsx
@@ -1,24 +1,61 @@
 import { updateScheduleNote } from '$actions/AppStoreActions';
-import AppStore from '$stores/AppStore';
-import { useFallbackStore } from '$stores/FallbackStore';
+import { useAppStoreScheduleIndex, useScheduleNoteSnapshot } from '$hooks/useAppStoreSchedule';
 import { Box, TextField, Typography } from '@mui/material';
 import { SCHEDULE_NOTE_MAX_LENGTH } from '@packages/antalmanac-types';
 import { useCallback, useEffect, useState } from 'react';
-import { useShallow } from 'zustand/react/shallow';
 
-export function ScheduleNoteBox() {
-    const { fallbackMode, getCurrentFallbackSchedule } = useFallbackStore(
-        useShallow((store) => ({
-            fallbackMode: store.fallbackMode,
-            getCurrentFallbackSchedule: store.getCurrentFallbackSchedule,
-        }))
+type ScheduleNoteBoxProps = {
+    scheduleNote?: string;
+};
+
+export function ScheduleNoteBox({ scheduleNote: scheduleNoteProp }: ScheduleNoteBoxProps) {
+    if (scheduleNoteProp !== undefined) {
+        return <ScheduleNoteBoxReadOnly scheduleNote={scheduleNoteProp} />;
+    }
+
+    return <ScheduleNoteBoxEditable />;
+}
+
+function ScheduleNoteBoxReadOnly({ scheduleNote }: { scheduleNote: string }) {
+    return (
+        <Box>
+            <Typography variant="h6">Schedule Notes</Typography>
+
+            <TextField
+                type="text"
+                color="secondary"
+                variant="filled"
+                label="Click here to start typing!"
+                value={scheduleNote}
+                inputProps={{
+                    maxLength: SCHEDULE_NOTE_MAX_LENGTH,
+                    style: { cursor: 'not-allowed' },
+                }}
+                InputLabelProps={{
+                    variant: 'filled',
+                }}
+                InputProps={{ disableUnderline: true }}
+                fullWidth
+                multiline
+                disabled
+                sx={{
+                    '& .MuiInputBase-root': {
+                        cursor: 'not-allowed',
+                    },
+                }}
+            />
+        </Box>
     );
-    const [scheduleNote, setScheduleNote] = useState(
-        fallbackMode
-            ? getCurrentFallbackSchedule(AppStore.getCurrentScheduleIndex()).scheduleNote
-            : AppStore.getCurrentScheduleNote()
-    );
-    const [scheduleIndex, setScheduleIndex] = useState(AppStore.getCurrentScheduleIndex());
+}
+
+function ScheduleNoteBoxEditable() {
+    const scheduleIndex = useAppStoreScheduleIndex();
+    const storeScheduleNote = useScheduleNoteSnapshot();
+    const [scheduleNote, setScheduleNote] = useState(storeScheduleNote);
+
+    useEffect(() => {
+        setScheduleNote(storeScheduleNote);
+    }, [storeScheduleNote]);
 
     const handleNoteChange = useCallback(
         (event: React.ChangeEvent<HTMLTextAreaElement>) => {
@@ -27,30 +64,6 @@ export function ScheduleNoteBox() {
         },
         [scheduleIndex]
     );
-
-    useEffect(() => {
-        const handleScheduleNoteChange = () => {
-            const { fallbackMode, getCurrentFallbackSchedule } = useFallbackStore.getState();
-            if (fallbackMode) {
-                const idx = AppStore.getCurrentScheduleIndex();
-                setScheduleNote(getCurrentFallbackSchedule(idx).scheduleNote);
-            } else {
-                setScheduleNote(AppStore.getCurrentScheduleNote());
-            }
-        };
-
-        const handleScheduleIndexChange = () => {
-            setScheduleIndex(AppStore.getCurrentScheduleIndex());
-        };
-
-        AppStore.on('scheduleNotesChange', handleScheduleNoteChange);
-        AppStore.on('currentScheduleIndexChange', handleScheduleIndexChange);
-
-        return () => {
-            AppStore.off('scheduleNotesChange', handleScheduleNoteChange);
-            AppStore.off('currentScheduleIndexChange', handleScheduleIndexChange);
-        };
-    }, []);
 
     return (
         <Box>
@@ -65,7 +78,7 @@ export function ScheduleNoteBox() {
                 value={scheduleNote}
                 inputProps={{
                     maxLength: SCHEDULE_NOTE_MAX_LENGTH,
-                    style: { cursor: fallbackMode ? 'not-allowed' : 'text' },
+                    style: { cursor: 'text' },
                 }}
                 InputLabelProps={{
                     variant: 'filled',
@@ -73,10 +86,9 @@ export function ScheduleNoteBox() {
                 InputProps={{ disableUnderline: true }}
                 fullWidth
                 multiline
-                disabled={fallbackMode}
                 sx={{
                     '& .MuiInputBase-root': {
-                        cursor: fallbackMode ? 'not-allowed' : 'text',
+                        cursor: 'text',
                     },
                 }}
             />

--- a/apps/antalmanac/src/hooks/useAppStoreSchedule.ts
+++ b/apps/antalmanac/src/hooks/useAppStoreSchedule.ts
@@ -1,0 +1,62 @@
+import AppStore from '$stores/AppStore';
+import { useFallbackStore } from '$stores/FallbackStore';
+import type { RepeatingCustomEvent } from '@packages/antalmanac-types';
+import { useSyncExternalStore } from 'react';
+
+function subscribeToScheduleIndex(onStoreChange: () => void) {
+    AppStore.on('currentScheduleIndexChange', onStoreChange);
+    return () => {
+        AppStore.off('currentScheduleIndexChange', onStoreChange);
+    };
+}
+
+export function useAppStoreScheduleIndex(): number {
+    return useSyncExternalStore(
+        subscribeToScheduleIndex,
+        () => AppStore.getCurrentScheduleIndex(),
+        () => AppStore.getCurrentScheduleIndex()
+    );
+}
+
+function subscribeToCustomEvents(onStoreChange: () => void) {
+    AppStore.on('customEventsChange', onStoreChange);
+    AppStore.on('currentScheduleIndexChange', onStoreChange);
+    return () => {
+        AppStore.off('customEventsChange', onStoreChange);
+        AppStore.off('currentScheduleIndexChange', onStoreChange);
+    };
+}
+
+function getCurrentCustomEventsSnapshot(): RepeatingCustomEvent[] {
+    const { fallbackMode, getCurrentFallbackSchedule } = useFallbackStore.getState();
+    if (fallbackMode) {
+        const index = AppStore.getCurrentScheduleIndex();
+        return [...getCurrentFallbackSchedule(index).customEvents];
+    }
+    return [...AppStore.schedule.getCurrentCustomEvents()];
+}
+
+export function useCurrentCustomEvents(): RepeatingCustomEvent[] {
+    return useSyncExternalStore(
+        subscribeToCustomEvents,
+        getCurrentCustomEventsSnapshot,
+        getCurrentCustomEventsSnapshot
+    );
+}
+
+function subscribeToScheduleNote(onStoreChange: () => void) {
+    AppStore.on('scheduleNotesChange', onStoreChange);
+    AppStore.on('currentScheduleIndexChange', onStoreChange);
+    return () => {
+        AppStore.off('scheduleNotesChange', onStoreChange);
+        AppStore.off('currentScheduleIndexChange', onStoreChange);
+    };
+}
+
+export function useScheduleNoteSnapshot(): string {
+    return useSyncExternalStore(
+        subscribeToScheduleNote,
+        () => AppStore.getCurrentScheduleNote(),
+        () => AppStore.getCurrentScheduleNote()
+    );
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Reduces duplicated `AppStore` event subscriptions and mount-only `useEffect` mirroring in the added-courses fallback pane (`FallbackSchedule`, `CustomEventsBox`, `ScheduleNoteBox`).

## Changes

- Added `useAppStoreSchedule.ts` with `useSyncExternalStore`-based hooks:
  - `useAppStoreScheduleIndex`
  - `useCurrentCustomEvents` (non-fallback / `AddedSectionsGrid` path)
  - `useScheduleNoteSnapshot` (editable note path)
- `FallbackSchedule` now owns the single schedule-index subscription and passes `customEvents` / `scheduleNote` from the current fallback schedule into children.
- `CustomEventsBox` and `ScheduleNoteBox` split into prop-driven (fallback) vs store-driven (normal) branches so fallback children do not register their own AppStore listeners.
- `ScheduleNoteBox` keeps local draft state only in the editable branch, synced from the store snapshot when external updates occur.

## Removed / consolidated subscriptions

| Component | Before | After |
|-----------|--------|-------|
| `FallbackSchedule` | `useState` + `useEffect` on `currentScheduleIndexChange` | `useAppStoreScheduleIndex` |
| `CustomEventsBox` (fallback) | `useState` + `useEffect` on `customEventsChange` + `currentScheduleIndexChange` | Props from parent (no AppStore listeners) |
| `CustomEventsBox` (normal) | Same effect pattern | `useCurrentCustomEvents` |
| `ScheduleNoteBox` (fallback) | `useState` + `useEffect` on `scheduleNotesChange` + `currentScheduleIndexChange` | Read-only props (no AppStore listeners) |
| `ScheduleNoteBox` (normal) | Same effect pattern | `useScheduleNoteSnapshot` + `useAppStoreScheduleIndex`; one `useEffect` to sync draft from snapshot |

Behavior should be unchanged: fallback notes remain read-only, editable notes still update `AppStore` on change, and custom events / schedule index still react to the same store events.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-43f1ddc5-e5d2-4ea6-8ebd-9a29fd6d89c1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-43f1ddc5-e5d2-4ea6-8ebd-9a29fd6d89c1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

