### PR TITLE
Promote @packages/db to dependencies and normalize friends router import

### DIFF
--- a/apps/antalmanac/package.json
+++ b/apps/antalmanac/package.json
@@ -34,6 +34,7 @@
         "@mui/x-date-pickers": "^8.11.1",
         "@packages/antalmanac-types": "workspace:^",
         "@packages/anteater-api": "workspace:^",
+        "@packages/db": "workspace:^",
         "@paralleldrive/cuid2": "^2.2.2",
         "@reactour/tour": "^3.7.0",
         "@tanstack/react-query": "^5.100.9",
@@ -73,7 +74,6 @@
     },
     "devDependencies": {
         "@babel/core": "^7.28.6",
-        "@packages/db": "workspace:^",
         "@testing-library/react": "^14.0.0",
         "@types/file-saver": "^2.0.5",
         "@types/leaflet": "^1.9.14",

--- a/apps/antalmanac/src/backend/routers/friends.ts
+++ b/apps/antalmanac/src/backend/routers/friends.ts
@@ -1,6 +1,6 @@
 import { RDS } from '$src/backend/lib/rds';
 import { protectedProcedure, router } from '$src/backend/trpc';
-import { db } from '@packages/db/src';
+import { db } from '@packages/db';
 import { TRPCError } from '@trpc/server';
 import { z } from 'zod';
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -146,6 +146,9 @@ importers:
       '@packages/anteater-api':
         specifier: workspace:^
         version: link:../../packages/anteater-api
+      '@packages/db':
+        specifier: workspace:^
+        version: link:../../packages/db
       '@paralleldrive/cuid2':
         specifier: ^2.2.2
         version: 2.2.2
@@ -258,9 +261,6 @@ importers:
       '@babel/core':
         specifier: ^7.28.6
         version: 7.29.0
-      '@packages/db':
-        specifier: workspace:^
-        version: link:../../packages/db
       '@testing-library/react':
         specifier: ^14.0.0
         version: 14.3.1(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Move `@packages/db` from `devDependencies` to `dependencies` in `apps/antalmanac/package.json` since backend routers use it at runtime.
- Change `friends.ts` to import `db` from `@packages/db` instead of `@packages/db/src`, matching other routers (`auth.ts`, `schedule.ts`, etc.).
- Update `pnpm-lock.yaml` to reflect the dependency classification change.

## Verification

- `pnpm install` completed successfully
- `pnpm --filter antalmanac build` succeeds (compile + TypeScript + static generation) with required env vars set
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ceaeb5de-60e0-44d6-8e95-90c9793b50f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ceaeb5de-60e0-44d6-8e95-90c9793b50f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

