### PR TITLE
revert: drop ActionCell and NotificationsTabs from Zustand shallow pass

### DIFF
--- a/apps/antalmanac/src/components/RightPane/AddedCourses/Notifications/NotificationsTabs.tsx
+++ b/apps/antalmanac/src/components/RightPane/AddedCourses/Notifications/NotificationsTabs.tsx
@@ -4,7 +4,6 @@ import { NotificationAddOutlined } from '@mui/icons-material';
 import { TabContext, TabList, TabPanel } from '@mui/lab';
 import { Box, Tab, Paper, CircularProgress, Typography, useTheme } from '@mui/material';
 import { useMemo, useState } from 'react';
-import { useShallow } from 'zustand/react/shallow';
 
 function groupNotificationsByTerm(notifications: Partial<Record<string, Notification>>) {
     return Object.entries(notifications).reduce<Record<string, string[]>>((groups, [key, notification]) => {
@@ -23,9 +22,8 @@ function groupNotificationsByTerm(notifications: Partial<Record<string, Notifica
 
 export function NotificationsTabs() {
     const theme = useTheme();
-    const { initialized, notifications } = useNotificationStore(
-        useShallow((store) => ({ initialized: store.initialized, notifications: store.notifications }))
-    );
+    const initialized = useNotificationStore((store) => store.initialized);
+    const notifications = useNotificationStore((store) => store.notifications);
 
     const groups = useMemo(() => groupNotificationsByTerm(notifications), [notifications]);
     const sortedTerms = useMemo(() => Object.keys(groups).sort(), [groups]);

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/action-cell/ActionCell.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/action-cell/ActionCell.tsx
@@ -11,7 +11,6 @@ import { Visibility, VisibilityOff, VisibilityOutlined } from '@mui/icons-materi
 import { Box, CircularProgress, IconButton, Tooltip } from '@mui/material';
 import type { AASection, CourseDetails } from '@packages/antalmanac-types';
 import { memo, useCallback } from 'react';
-import { useShallow } from 'zustand/react/shallow';
 
 interface ActionCellProps {
     section: AASection;
@@ -25,11 +24,9 @@ interface ActionCellProps {
 export const ActionCell = memo(
     ({ section, term, courseDetails, scheduleConflict, addedCourse, scheduleNames }: ActionCellProps) => {
         const initialized = useNotificationStore((state) => state.initialized);
-        const [cycleVisibility, classVisibility] = useHiddenCoursesStore(
-            useShallow((state) => [
-                state.cycleVisibility,
-                state.getVisibility(AppStore.getCurrentScheduleId(), section.sectionCode),
-            ])
+        const cycleVisibility = useHiddenCoursesStore((state) => state.cycleVisibility);
+        const classVisibility = useHiddenCoursesStore((state) =>
+            state.getVisibility(AppStore.getCurrentScheduleId(), section.sectionCode)
         );
 
         const handleVisibilityToggle = useCallback(() => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Follow-up to #1832 / #1805: remove overlapping shallow-pass changes that duplicated #1805.

## Summary

#1832 re-applied `useShallow` in `ActionCell` and `NotificationsTabs`, which #1805 had already addressed (separate selectors). This PR reverts only those two files to match #1805.

The remaining #1832 `useShallow` work stays on `main` in:

- ReviewPrompt flow (`ReviewPrompt`, `ReviewStep`, `EnrollmentConfirmStep`)
- `NotificationTableRowCheckbox`
- `useQuickSearch`
- `AppThemeProvider` (`Theme.tsx`)

## Verification

- `pnpm lint` passes
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-89a2106e-79d5-4780-9009-6ca505c67345"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-89a2106e-79d5-4780-9009-6ca505c67345"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

