### PR TITLE
fix: return URL validation to fix encoding bug

### DIFF
--- a/apps/antalmanac/src/lib/auth/auth.ts
+++ b/apps/antalmanac/src/lib/auth/auth.ts
@@ -50,8 +50,8 @@ export const auth = betterAuth({
                     if (additionalData.returnUrl) {
                         const returnUrl = getSafeAuthRedirectPath(
                             additionalData.returnUrl,
-                            ctx.request?.url ?? '',
-                            BETTER_AUTH_URL
+                            ctx.request?.url,
+                            new URL(BETTER_AUTH_URL).origin
                         );
                         ctx.redirect(returnUrl);
                     }

--- a/apps/antalmanac/src/lib/auth/authUtils.ts
+++ b/apps/antalmanac/src/lib/auth/authUtils.ts
@@ -2,44 +2,23 @@ import { Provider } from '$lib/auth/authTypes';
 
 export const getSafeAuthRedirectPath = (
     redirectUrl: string | null | undefined,
-    requestUrl: string,
-    fallbackRequestUrl: string
+    requestUrl: string | null | undefined,
+    allowedOrigin: string
 ): string => {
     if (!redirectUrl) {
         return '/';
     }
 
-    let requestOrigin: string;
     try {
-        requestOrigin = new URL(requestUrl).origin;
-    } catch {
-        requestOrigin = new URL(fallbackRequestUrl).origin;
-    }
-
-    const candidates: string[] = [];
-    try {
-        const decodedRedirectUrl = decodeURIComponent(redirectUrl);
-        candidates.push(decodedRedirectUrl);
-    } catch {
-        // Ignore malformed encoding and continue with the raw value.
-    }
-
-    if (!candidates.includes(redirectUrl)) {
-        candidates.push(redirectUrl);
-    }
-
-    for (const candidate of candidates) {
-        try {
-            const parsedRedirectUrl = new URL(candidate, requestOrigin);
-            if (parsedRedirectUrl.origin === requestOrigin) {
-                return `${parsedRedirectUrl.pathname}${parsedRedirectUrl.search}${parsedRedirectUrl.hash}`;
-            }
-        } catch {
-            // Ignore malformed candidate and try next.
+        const requestOrigin = requestUrl ? new URL(requestUrl).origin : undefined;
+        const url = new URL(redirectUrl, requestOrigin);
+        if (url.origin === allowedOrigin) {
+            return url.toString();
         }
+        return '/';
+    } catch {
+        return '/';
     }
-
-    return '/';
 };
 
 export function getProviderDisplayName(provider: Provider) {

--- a/apps/antalmanac/src/lib/auth/authUtils.ts
+++ b/apps/antalmanac/src/lib/auth/authUtils.ts
@@ -10,7 +10,7 @@ export const getSafeAuthRedirectPath = (
     }
 
     try {
-        const requestOrigin = requestUrl ? new URL(requestUrl).origin : undefined;
+        const requestOrigin = requestUrl ? new URL(requestUrl).origin : allowedOrigin;
         const url = new URL(redirectUrl, requestOrigin);
         if (url.origin === allowedOrigin) {
             return url.toString();

--- a/apps/antalmanac/tests/authUtils.test.ts
+++ b/apps/antalmanac/tests/authUtils.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, test } from 'vitest';
+
+import { getSafeAuthRedirectPath } from '../src/lib/auth/authUtils';
+
+const VALID_URL = '/importRoadmap=1234&term=2026+Spring';
+const ALLOWED_ORIGIN = 'https://www.antalmanac.com';
+
+describe('getSafeAuthRedirectPath', () => {
+    test('Returns valid URL', () => {
+        expect(getSafeAuthRedirectPath(VALID_URL, ALLOWED_ORIGIN, ALLOWED_ORIGIN)).toStrictEqual(
+            ALLOWED_ORIGIN + VALID_URL
+        );
+    });
+
+    test('Returns root if URL origin is not allowed', () => {
+        expect(getSafeAuthRedirectPath('https://www.google.com', ALLOWED_ORIGIN, ALLOWED_ORIGIN)).toStrictEqual('/');
+    });
+});


### PR DESCRIPTION
## Summary

Refactors `getSafeAuthRedirectPath` to not decode the given URL. Handles open redirect attacks by checking against a pre-supplied allowed origin.

I think checking the URL's origin is enough to protect against attacks, but if there are other cases that should be considered, lmk

## Test Plan

1. Run `pnpm test` and ensure tests pass
2. Auth return URL still works. Testable by setting manual search field that sets a URL query param -> Sign in -> See that you are redirected to the same URL with the same query params

## Issues

Closes #1851

<!-- [Optional]
## Future Followup
-->
