### PR TITLE
perf(rds): parallelize independent schedule queries

### DIFF
--- a/apps/antalmanac/src/backend/lib/rds.ts
+++ b/apps/antalmanac/src/backend/lib/rds.ts
@@ -304,17 +304,18 @@ export class RDS {
                 return null;
             }
 
-            const sectionResults = await tx
-                .select()
-                .from(schedules)
-                .where(eq(schedules.id, scheduleId))
-                .leftJoin(coursesInSchedule, eq(schedules.id, coursesInSchedule.scheduleId));
-
-            const customEventResults = await tx
-                .select()
-                .from(schedules)
-                .where(eq(schedules.id, scheduleId))
-                .leftJoin(customEvents, eq(schedules.id, customEvents.scheduleId));
+            const [sectionResults, customEventResults] = await Promise.all([
+                tx
+                    .select()
+                    .from(schedules)
+                    .where(eq(schedules.id, scheduleId))
+                    .leftJoin(coursesInSchedule, eq(schedules.id, coursesInSchedule.scheduleId)),
+                tx
+                    .select()
+                    .from(schedules)
+                    .where(eq(schedules.id, scheduleId))
+                    .leftJoin(customEvents, eq(schedules.id, customEvents.scheduleId)),
+            ]);
 
             const scheduleArray = RDS.aggregateUserData(sectionResults, customEventResults);
             const result = scheduleArray[0];
@@ -397,17 +398,18 @@ export class RDS {
 
             const sharedCondition = and(eq(schedules.userId, userId), eq(schedules.sharedWithFriends, true));
 
-            const sectionResults = await tx
-                .select()
-                .from(schedules)
-                .where(sharedCondition)
-                .leftJoin(coursesInSchedule, eq(schedules.id, coursesInSchedule.scheduleId));
-
-            const customEventResults = await tx
-                .select()
-                .from(schedules)
-                .where(sharedCondition)
-                .leftJoin(customEvents, eq(schedules.id, customEvents.scheduleId));
+            const [sectionResults, customEventResults] = await Promise.all([
+                tx
+                    .select()
+                    .from(schedules)
+                    .where(sharedCondition)
+                    .leftJoin(coursesInSchedule, eq(schedules.id, coursesInSchedule.scheduleId)),
+                tx
+                    .select()
+                    .from(schedules)
+                    .where(sharedCondition)
+                    .leftJoin(customEvents, eq(schedules.id, customEvents.scheduleId)),
+            ]);
 
             const userSchedules = RDS.aggregateUserData(sectionResults, customEventResults);
 

--- a/apps/antalmanac/src/backend/routers/review.ts
+++ b/apps/antalmanac/src/backend/routers/review.ts
@@ -126,15 +126,16 @@ const reviewRouter = router({
      * Latest time the user dismissed a review prompt or submitted a quick review.
      */
     getReviewPromptLastInteractionAt: protectedProcedure.query(async ({ ctx }) => {
-        const [dismissRow] = await db
-            .select({ createdAt: max(reviewDismissals.createdAt) })
-            .from(reviewDismissals)
-            .where(eq(reviewDismissals.userId, ctx.userId));
-
-        const [reviewRow] = await db
-            .select({ createdAt: max(instructorReviews.createdAt) })
-            .from(instructorReviews)
-            .where(eq(instructorReviews.userId, ctx.userId));
+        const [[dismissRow], [reviewRow]] = await Promise.all([
+            db
+                .select({ createdAt: max(reviewDismissals.createdAt) })
+                .from(reviewDismissals)
+                .where(eq(reviewDismissals.userId, ctx.userId)),
+            db
+                .select({ createdAt: max(instructorReviews.createdAt) })
+                .from(instructorReviews)
+                .where(eq(instructorReviews.userId, ctx.userId)),
+        ]);
 
         const dismissedAt = dismissRow?.createdAt;
         const reviewedAt = reviewRow?.createdAt;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Parallelizes independent Drizzle selects with `Promise.all` in three remaining call sites that still ran section and custom-event queries sequentially:

- `RDS.getScheduleById` — courses and custom events for a single schedule
- `RDS.getUserFriendDataByUid` — shared friend schedules
- `review.getReviewPromptLastInteractionAt` — latest dismissal and review timestamps

`getGuestScheduleByUsername` and `fetchUserDataWithSession` were already parallelized on main.

## Test Plan

- [x] `pnpm lint` passes (0 warnings)
- [x] Vitest unit tests pass where generated data is available (23/23 runnable tests)
- [ ] Manual: load/save schedule (session restore, shareable schedule link)
- [ ] Manual: review prompt flow (dismiss + submit, cooldown timing)

## Issues

Resolves the three sequential-query warnings in `rds.ts` (2) and `review.ts` (1).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-916505da-1b91-409f-8a3f-f117fb7d19db"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-916505da-1b91-409f-8a3f-f117fb7d19db"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

