### PR TITLE
fix: cleanup SeoContent

### DIFF
--- a/apps/antalmanac/src/app/[[...slug]]/seo-content.tsx
+++ b/apps/antalmanac/src/app/[[...slug]]/seo-content.tsx
@@ -1,3 +1,5 @@
+import Link from 'next/link';
+
 import { ANTALMANAC_TITLE } from '$src/app/seo-constants';
 
 /**
@@ -13,7 +15,7 @@ export function SeoContent() {
             <h1>{ANTALMANAC_TITLE}</h1>
 
             <p>
-                AntAlmanac helps you find any UCI course and plan your UCI schedule in one place — a UCI course planner
+                AntAlmanac helps you find any UCI course and plan your UCI schedule in one place, a UCI course planner
                 and UCI schedule planner trusted by tens of thousands of UC Irvine students. Search UCI courses across
                 140+ departments, build your UCI schedule with conflict detection and unit counts, and explore grade
                 distributions and enrollment history before you enroll.
@@ -22,8 +24,8 @@ export function SeoContent() {
             <h2>UCI course search</h2>
             <p>
                 Run a UCI course search across Computer Science, Informatics, Biological Sciences, Mathematics,
-                Economics, Engineering, Psychology, Political Science, and 130+ more departments. Filter by GE category
-                — Writing, Multicultural Studies, Science &amp; Technology, and more — or search by course number,
+                Economics, Engineering, Psychology, Political Science, and 130+ more departments. Filter by GE category:
+                Writing, Multicultural Studies, Science &amp; Technology, and more, or search by course number,
                 title, or instructor name.
             </p>
 
@@ -50,23 +52,26 @@ export function SeoContent() {
             <nav aria-label="AntAlmanac sections">
                 <ul>
                     <li>
-                        <a href="/">UCI Course Search</a>
+                        <Link href="/">UCI Course Search</Link>
                     </li>
                     <li>
-                        <a href="/added">My Schedule</a>
+                        <Link href="/added">My Schedule</Link>
                     </li>
                     <li>
-                        <a href="/map">Campus Map</a>
+                        <Link href="/map">Campus Map</Link>
                     </li>
                     <li>
-                        <a href="/feedback">Feedback</a>
+                        <Link href="/feedback">Feedback</Link>
                     </li>
                 </ul>
             </nav>
 
             <footer>
                 <p>
-                    AntAlmanac is an open-source project by <a href="https://github.com/icssc">ICS Student Council</a>{' '}
+                    AntAlmanac is an open-source project by{' '}
+                    <a href="https://github.com/icssc" target="_blank" rel="noopener noreferrer">
+                        ICS Student Council
+                    </a>{' '}
                     at the University of California, Irvine.
                 </p>
             </footer>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes React Doctor warnings in `apps/antalmanac/src/app/[[...slug]]/seo-content.tsx` only.

- Replaced em dashes in sr-only SEO copy with commas/colons (no visible UI change).
- Swapped internal `<a href="...">` nav links for `next/link` `Link` components (`/`, `/added`, `/map`, `/feedback`).
- Kept the external GitHub link as a plain `<a>` with `target="_blank"` and `rel="noopener noreferrer"`.

`SeoContent` remains a server component (no `'use client'`).

## Test plan

- [ ] React Doctor no longer flags em dashes or internal anchor links in this file
- [ ] Typecheck/lint pass for antalmanac
- [ ] sr-only SEO content renders unchanged in page HTML
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ab1762fc-a8cb-402f-9f82-5751f8a57d3f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ab1762fc-a8cb-402f-9f82-5751f8a57d3f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

