### PR TITLE
fix: lazy-init AppStore snapshot state

### DIFF
--- a/apps/antalmanac/src/components/Calendar/Toolbar/ScheduleSelect/ScheduleSelect.tsx
+++ b/apps/antalmanac/src/components/Calendar/Toolbar/ScheduleSelect/ScheduleSelect.tsx
@@ -54,8 +54,8 @@ export function SelectSchedulePopover() {
         }))
     );
 
-    const [currentScheduleIndex, setCurrentScheduleIndex] = useState(AppStore.getCurrentScheduleIndex());
-    const [scheduleMapping, setScheduleMapping] = useState(getScheduleItems());
+    const [currentScheduleIndex, setCurrentScheduleIndex] = useState(() => AppStore.getCurrentScheduleIndex());
+    const [scheduleMapping, setScheduleMapping] = useState(() => getScheduleItems());
     const { fallbackMode, getFallbackScheduleNames } = useFallbackStore(
         useShallow((store) => ({
             fallbackMode: store.fallbackMode,

--- a/apps/antalmanac/src/components/Map/Map.tsx
+++ b/apps/antalmanac/src/components/Map/Map.tsx
@@ -164,9 +164,9 @@ export default function CourseMap() {
     const markerRef = useRef<Marker | null>(null);
     const [searchParams] = useSearchParams();
     const [selectedDayIndex, setSelectedDay] = useState(0);
-    const [markers, setMarkers] = useState(getCoursesPerBuilding());
-    const [customEventMarkers, setCustomEventMarkers] = useState(getCustomEventPerBuilding());
-    const [calendarEvents, setCalendarEvents] = useState(AppStore.getEventsInCalendar());
+    const [markers, setMarkers] = useState(() => getCoursesPerBuilding());
+    const [customEventMarkers, setCustomEventMarkers] = useState(() => getCustomEventPerBuilding());
+    const [calendarEvents, setCalendarEvents] = useState(() => AppStore.getEventsInCalendar());
     const postHog = usePostHog();
 
     useEffect(() => {

--- a/apps/antalmanac/src/components/RightPane/AddedCourses/AddedSectionsGrid.tsx
+++ b/apps/antalmanac/src/components/RightPane/AddedCourses/AddedSectionsGrid.tsx
@@ -119,8 +119,8 @@ function getCourses() {
 
 export function AddedSectionsGrid() {
     const [courses, setCourses] = useState(getCourses);
-    const [scheduleNames, setScheduleNames] = useState(AppStore.getScheduleNames());
-    const [scheduleIndex, setScheduleIndex] = useState(AppStore.getCurrentScheduleIndex());
+    const [scheduleNames, setScheduleNames] = useState(() => AppStore.getScheduleNames());
+    const [scheduleIndex, setScheduleIndex] = useState(() => AppStore.getCurrentScheduleIndex());
     const loadingSchedule = useScheduleComponentsToggleStore((state) => state.openLoadingSchedule);
 
     const handleCourseOrderChange = (updatedCourses: CourseWithTerm[], _activeIndex: number, overIndex: number) => {

--- a/apps/antalmanac/src/components/RightPane/AddedCourses/FallbackSchedule.tsx
+++ b/apps/antalmanac/src/components/RightPane/AddedCourses/FallbackSchedule.tsx
@@ -11,7 +11,7 @@ import { useEffect, useMemo, useState } from 'react';
 
 export function FallbackSchedule() {
     const getCurrentFallbackSchedule = useFallbackStore((store) => store.getCurrentFallbackSchedule);
-    const [currentScheduleIndex, setCurrentScheduleIndex] = useState(AppStore.getCurrentScheduleIndex());
+    const [currentScheduleIndex, setCurrentScheduleIndex] = useState(() => AppStore.getCurrentScheduleIndex());
     const postHog = usePostHog();
 
     useEffect(() => {

--- a/apps/antalmanac/src/components/RightPane/AddedCourses/ScheduleNoteBox.tsx
+++ b/apps/antalmanac/src/components/RightPane/AddedCourses/ScheduleNoteBox.tsx
@@ -18,7 +18,7 @@ export function ScheduleNoteBox() {
             ? getCurrentFallbackSchedule(AppStore.getCurrentScheduleIndex()).scheduleNote
             : AppStore.getCurrentScheduleNote()
     );
-    const [scheduleIndex, setScheduleIndex] = useState(AppStore.getCurrentScheduleIndex());
+    const [scheduleIndex, setScheduleIndex] = useState(() => AppStore.getCurrentScheduleIndex());
 
     const handleNoteChange = useCallback(
         (event: React.ChangeEvent<HTMLTextAreaElement>) => {

--- a/apps/antalmanac/src/components/RightPane/CoursePane/CourseRenderPane.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/CourseRenderPane.tsx
@@ -287,7 +287,7 @@ const ErrorMessage = () => {
 
 export default function CourseRenderPane(props: { id?: number }) {
     const [courseColors, setCourseColors] = useState(getColors);
-    const [scheduleNames, setScheduleNames] = useState(AppStore.getScheduleNames());
+    const [scheduleNames, setScheduleNames] = useState(() => AppStore.getScheduleNames());
     const [unofferedCourses, setUnofferedCourses] = useState<CourseSearchParams[]>([]);
     const [searchedTerm, setSearchedTerm] = useState(() => RightPaneStore.getFormData().term.longName);
 

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody/SectionTableBodyRow.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody/SectionTableBodyRow.tsx
@@ -65,7 +65,7 @@ export const SectionTableBodyRow = memo((props: SectionTableBodyRowProps) => {
     const previewMode = usePreviewStore((store) => store.previewMode);
     const setHoveredEvent = useHoveredStore((store) => store.setHoveredEvent);
 
-    const [addedCourse, setAddedCourse] = useState(
+    const [addedCourse, setAddedCourse] = useState(() =>
         AppStore.getAddedSectionCodes().has(`${section.sectionCode} ${term.shortName}`)
     );
 

--- a/apps/antalmanac/src/components/dialogs/AddSchedule.tsx
+++ b/apps/antalmanac/src/components/dialogs/AddSchedule.tsx
@@ -8,7 +8,7 @@ import { useState } from 'react';
  * Dialog with a text field to add a schedule.
  */
 function AddScheduleDialog({ onClose, onKeyDown, ...props }: DialogProps) {
-    const [name, setName] = useState(
+    const [name, setName] = useState(() =>
         AppStore.getNextScheduleName(AppStore.getScheduleNames().length, AppStore.getDefaultScheduleName())
     );
 

--- a/apps/antalmanac/src/components/dialogs/RenameSchedule.tsx
+++ b/apps/antalmanac/src/components/dialogs/RenameSchedule.tsx
@@ -33,7 +33,7 @@ function RenameScheduleDialog(props: ScheduleNameDialogProps) {
      * This is destructured separately for memoization.
      */
     const { onClose } = props;
-    const [name, setName] = useState(AppStore.getScheduleNames()[index]);
+    const [name, setName] = useState(() => AppStore.getScheduleNames()[index]);
 
     const handleCancel = useCallback(() => {
         onClose?.({}, 'escapeKeyDown');


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Wraps eager `useState` initializers in lazy arrow functions so AppStore snapshot reads only run once on mount, not on every re-render. Resolves 13 `rerender-lazy-state-init` warnings across schedule, map, and section-table components.

Mechanical change: `useState(x())` → `useState(() => x())`.

## Test Plan

- [x] `pnpm lint` passes
- [ ] Smoke-test schedule switching (ScheduleSelect, AddedSectionsGrid, FallbackSchedule)
- [ ] Smoke-test map view (Map markers/events)
- [ ] Smoke-test notifications tab and section table row add state

## Issues

Closes #
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2723aa55-7b2e-4e1f-83fe-ec814454a208"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2723aa55-7b2e-4e1f-83fe-ec814454a208"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

