### PR TITLE
refactor: lazy-load recharts in section table popovers

### DIFF
--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTablePopover/EnrollmentHistoryPopover.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTablePopover/EnrollmentHistoryPopover.tsx
@@ -3,20 +3,15 @@ import { trpcReact } from '$lib/api/trpc';
 import { parseAndSortEnrollmentHistory, type EnrollmentHistory } from '$lib/enrollmentHistory';
 import { ArrowBack, ArrowForward } from '@mui/icons-material';
 import { Box, Card, CardContent, CardHeader, IconButton, Skeleton, Tooltip, Typography } from '@mui/material';
-import { useTheme } from '@mui/material/styles';
 import type { AATerm } from '@packages/antalmanac-types';
 import type { WebsocSectionType } from '@packages/anteater-api/types';
+import dynamic from 'next/dynamic';
 import { useCallback, useMemo, useState } from 'react';
-import {
-    CartesianGrid,
-    Legend,
-    Line,
-    LineChart,
-    Tooltip as RechartsTooltip,
-    ResponsiveContainer,
-    XAxis,
-    YAxis,
-} from 'recharts';
+
+const EnrollmentHistoryPopoverChart = dynamic(() => import('./EnrollmentHistoryPopoverChart'), {
+    ssr: false,
+    loading: () => <Skeleton variant="rectangular" animation="wave" height="100%" width="100%" />,
+});
 
 interface EnrollmentHistoryPopoverProps {
     sectionType: WebsocSectionType;
@@ -43,7 +38,6 @@ export function EnrollmentHistoryPopover({
     );
     const [selectedGraphKey, setSelectedGraphKey] = useState<string>();
 
-    const theme = useTheme();
     const isMobile = useIsMobile();
 
     const width = isMobile ? 280 : 400;
@@ -77,8 +71,6 @@ export function EnrollmentHistoryPopover({
         ) : (
             <>&nbsp;</>
         );
-
-    const chartColors = theme.palette.enrollmentStatus;
 
     const handleBack = useCallback(() => {
         if (!enrollmentHistory?.length || activeGraphIndex === 0) {
@@ -155,49 +147,7 @@ export function EnrollmentHistoryPopover({
                     </Box>
                 ) : (
                     <Box sx={{ display: 'flex', height, width }}>
-                        <ResponsiveContainer>
-                            <LineChart data={enrollmentHistory[activeGraphIndex].days} style={{ cursor: 'pointer' }}>
-                                <CartesianGrid strokeDasharray="3 3" vertical={false} />
-                                <RechartsTooltip contentStyle={{ backgroundColor: theme.palette.background.paper }} />
-                                <Legend wrapperStyle={{ left: 0, width: '100%' }} />
-
-                                <XAxis dataKey="date" tick={{ fontSize: 12, fill: theme.palette.text.primary }} />
-                                <YAxis tick={{ fontSize: 12, fill: theme.palette.text.primary }} width={35} />
-
-                                <Line
-                                    type="monotone"
-                                    dataKey="totalEnrolled"
-                                    stroke={chartColors.open}
-                                    name="Enrolled"
-                                    strokeWidth={2}
-                                    dot={false}
-                                    activeDot={{ r: 4 }}
-                                    isAnimationActive={false}
-                                />
-                                <Line
-                                    type="monotone"
-                                    dataKey="maxCapacity"
-                                    stroke={chartColors.full}
-                                    name="Capacity"
-                                    strokeWidth={2}
-                                    strokeDasharray="16 24"
-                                    dot={false}
-                                    activeDot={{ r: 3 }}
-                                    isAnimationActive={false}
-                                />
-                                <Line
-                                    type="monotone"
-                                    dataKey="waitlist"
-                                    stroke={chartColors.waitlist}
-                                    name="Waitlist"
-                                    strokeWidth={2}
-                                    dot={false}
-                                    connectNulls
-                                    activeDot={{ r: 3 }}
-                                    isAnimationActive={false}
-                                />
-                            </LineChart>
-                        </ResponsiveContainer>
+                        <EnrollmentHistoryPopoverChart days={enrollmentHistory[activeGraphIndex].days} />
                     </Box>
                 )}
             </CardContent>

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTablePopover/EnrollmentHistoryPopoverChart.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTablePopover/EnrollmentHistoryPopoverChart.tsx
@@ -1,0 +1,67 @@
+import type { EnrollmentHistoryDay } from '$lib/enrollmentHistory';
+import { useTheme } from '@mui/material/styles';
+import {
+    CartesianGrid,
+    Legend,
+    Line,
+    LineChart,
+    Tooltip as RechartsTooltip,
+    ResponsiveContainer,
+    XAxis,
+    YAxis,
+} from 'recharts';
+
+interface EnrollmentHistoryPopoverChartProps {
+    days: EnrollmentHistoryDay[];
+}
+
+export default function EnrollmentHistoryPopoverChart({ days }: EnrollmentHistoryPopoverChartProps) {
+    const theme = useTheme();
+    const chartColors = theme.palette.enrollmentStatus;
+
+    return (
+        <ResponsiveContainer>
+            <LineChart data={days} style={{ cursor: 'pointer' }}>
+                <CartesianGrid strokeDasharray="3 3" vertical={false} />
+                <RechartsTooltip contentStyle={{ backgroundColor: theme.palette.background.paper }} />
+                <Legend wrapperStyle={{ left: 0, width: '100%' }} />
+
+                <XAxis dataKey="date" tick={{ fontSize: 12, fill: theme.palette.text.primary }} />
+                <YAxis tick={{ fontSize: 12, fill: theme.palette.text.primary }} width={35} />
+
+                <Line
+                    type="monotone"
+                    dataKey="totalEnrolled"
+                    stroke={chartColors.open}
+                    name="Enrolled"
+                    strokeWidth={2}
+                    dot={false}
+                    activeDot={{ r: 4 }}
+                    isAnimationActive={false}
+                />
+                <Line
+                    type="monotone"
+                    dataKey="maxCapacity"
+                    stroke={chartColors.full}
+                    name="Capacity"
+                    strokeWidth={2}
+                    strokeDasharray="16 24"
+                    dot={false}
+                    activeDot={{ r: 3 }}
+                    isAnimationActive={false}
+                />
+                <Line
+                    type="monotone"
+                    dataKey="waitlist"
+                    stroke={chartColors.waitlist}
+                    name="Waitlist"
+                    strokeWidth={2}
+                    dot={false}
+                    connectNulls
+                    activeDot={{ r: 3 }}
+                    isAnimationActive={false}
+                />
+            </LineChart>
+        </ResponsiveContainer>
+    );
+}

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTablePopover/GradesPopover.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTablePopover/GradesPopover.tsx
@@ -7,12 +7,16 @@ import {
     Card,
     CardHeader,
     CardContent,
-    useTheme,
     Skeleton,
 } from '@mui/material';
 import type { AggregateGrades } from '@packages/anteater-api/types';
+import dynamic from 'next/dynamic';
 import { useMemo, useState } from 'react';
-import { Bar, BarChart, CartesianGrid, ResponsiveContainer, Tooltip as RechartsTooltip, XAxis, YAxis } from 'recharts';
+
+const GradesPopoverChart = dynamic(() => import('./GradesPopoverChart'), {
+    ssr: false,
+    loading: () => <Skeleton variant="rectangular" animation="wave" height="100%" width="100%" />,
+});
 
 type GradeView = 'instructor' | 'overall';
 
@@ -54,9 +58,6 @@ interface GradesPopoverProps {
 }
 
 export function GradesPopover(props: GradesPopoverProps) {
-    const theme = useTheme();
-    const secondaryColor = theme.palette.secondary.main;
-
     const { deptCode, courseNumber, instructor = '', isMobile } = props;
 
     const { data: overallGrades, isLoading: overallLoading } = trpcReact.grades.aggregateGrades.useQuery(
@@ -132,32 +133,7 @@ export function GradesPopover(props: GradesPopoverProps) {
                     </Box>
                 ) : activeData && hasData ? (
                     <Box sx={{ width, height }}>
-                        <ResponsiveContainer>
-                            <BarChart data={activeData.grades} style={{ cursor: 'pointer' }}>
-                                <CartesianGrid strokeDasharray="3 3" vertical={false} />
-                                <XAxis
-                                    dataKey="name"
-                                    tick={{ fontSize: 12, fill: theme.palette.text.primary }}
-                                    height={20}
-                                />
-                                <YAxis tick={{ fontSize: 12, fill: theme.palette.text.primary }} unit="%" width={35} />
-                                <RechartsTooltip
-                                    contentStyle={{
-                                        backgroundColor: theme.palette.background.paper,
-                                        border: 0,
-                                    }}
-                                    labelStyle={{ color: secondaryColor }}
-                                    itemStyle={{ color: secondaryColor }}
-                                    labelFormatter={(gradeLabel) => `Grade ${gradeLabel}`}
-                                    formatter={(value) => {
-                                        const n = typeof value === 'number' ? value : Number(value);
-                                        const pct = Number.isFinite(n) ? n.toFixed(1) : String(value);
-                                        return [`${pct}%`];
-                                    }}
-                                />
-                                <Bar dataKey="all" fill={theme.palette.primary.main} />
-                            </BarChart>
-                        </ResponsiveContainer>
+                        <GradesPopoverChart grades={activeData.grades} />
                     </Box>
                 ) : (
                     <Box

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTablePopover/GradesPopoverChart.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTablePopover/GradesPopoverChart.tsx
@@ -1,0 +1,39 @@
+import { useTheme } from '@mui/material/styles';
+import { Bar, BarChart, CartesianGrid, ResponsiveContainer, Tooltip as RechartsTooltip, XAxis, YAxis } from 'recharts';
+
+interface GradesPopoverChartProps {
+    grades: {
+        name: string;
+        all: number;
+    }[];
+}
+
+export default function GradesPopoverChart({ grades }: GradesPopoverChartProps) {
+    const theme = useTheme();
+    const secondaryColor = theme.palette.secondary.main;
+
+    return (
+        <ResponsiveContainer>
+            <BarChart data={grades} style={{ cursor: 'pointer' }}>
+                <CartesianGrid strokeDasharray="3 3" vertical={false} />
+                <XAxis dataKey="name" tick={{ fontSize: 12, fill: theme.palette.text.primary }} height={20} />
+                <YAxis tick={{ fontSize: 12, fill: theme.palette.text.primary }} unit="%" width={35} />
+                <RechartsTooltip
+                    contentStyle={{
+                        backgroundColor: theme.palette.background.paper,
+                        border: 0,
+                    }}
+                    labelStyle={{ color: secondaryColor }}
+                    itemStyle={{ color: secondaryColor }}
+                    labelFormatter={(gradeLabel) => `Grade ${gradeLabel}`}
+                    formatter={(value) => {
+                        const n = typeof value === 'number' ? value : Number(value);
+                        const pct = Number.isFinite(n) ? n.toFixed(1) : String(value);
+                        return [`${pct}%`];
+                    }}
+                />
+                <Bar dataKey="all" fill={theme.palette.primary.main} />
+            </BarChart>
+        </ResponsiveContainer>
+    );
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Enrollment history and grade distribution popovers statically imported `recharts`, so that library was included in the main schedule page bundle even though most users never open those charts.

This change splits chart rendering into `EnrollmentHistoryPopoverChart` and `GradesPopoverChart`, loaded via `next/dynamic` with `ssr: false`. Popover shells (data fetching, card chrome, navigation) stay in the existing components. Recharts loads only on first chart render, with the existing `Skeleton` reused for the brief chunk load.

**Expected impact:** ~100–130 KB gzip removed from the critical path for first paint / TTI on the home route. Repeat opens use the cached lazy chunk.

## Test Plan

- [ ] Open the schedule page and confirm no console errors on load
- [ ] Click enrollment count in the section table → popover shows skeleton then line chart; navigate older/newer graphs
- [ ] Click GPA in the section table → popover shows skeleton then bar chart; toggle instructor vs overall
- [ ] Verify network tab: `recharts` chunk loads on first popover open, not on initial page load

## Issues

Closes #
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-97bad298-d5a4-4012-aad6-cb1122bdcc98"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-97bad298-d5a4-4012-aad6-cb1122bdcc98"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

