### PR TITLE
fix: misc cleanup

### DIFF
--- a/apps/antalmanac/src/components/Calendar/Toolbar/CustomEventDialog/DaySelector.tsx
+++ b/apps/antalmanac/src/components/Calendar/Toolbar/CustomEventDialog/DaySelector.tsx
@@ -11,7 +11,7 @@ export function DaySelector({
     days = [false, false, false, false, false, false, false],
     onSelectDay,
 }: DaySelectorProps) {
-    const daysValue = days.map((day, index) => (day ? DAYS.at(index) : false)).filter(Boolean);
+    const daysValue = days.flatMap((day, index) => (day ? [DAYS[index]] : []));
 
     const handleChange = (_event: unknown, value: typeof DAYS) => {
         const newDays = DAYS.map((d) => value.includes(d));

--- a/apps/antalmanac/src/components/RightPane/AddedCourses/Notifications/NotificationsTabs.tsx
+++ b/apps/antalmanac/src/components/RightPane/AddedCourses/Notifications/NotificationsTabs.tsx
@@ -30,7 +30,7 @@ export function NotificationsTabs() {
     const groups = useMemo(() => groupNotificationsByTerm(notifications), [notifications]);
     const sortedTerms = useMemo(() => Object.keys(groups).sort(), [groups]);
 
-    const [activeTab, setActiveTab] = useState(sortedTerms.at(0));
+    const [activeTab, setActiveTab] = useState(() => sortedTerms.at(0));
     const displayTab = activeTab ?? sortedTerms.at(0);
     const handleTabChange = (_: React.SyntheticEvent, newValue: string) => {
         setActiveTab(newValue);

--- a/apps/antalmanac/src/components/RightPane/CoursePane/CourseRenderPane.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/CourseRenderPane.tsx
@@ -334,7 +334,7 @@ export default function CourseRenderPane(props: { id?: number }) {
                 if (multiSearchData.length > 0) {
                     const { year, quarter } = RightPaneStore.getFormData().term;
                     const offeredCourses: WebsocSearchInput[] = [];
-                    const unofferedCourses: CourseSearchParams[] = [];
+                    const nextUnoffered: CourseSearchParams[] = [];
                     const offeredCoursesMapping = await trpc.search.filterOfferedCourses.query({
                         term: { year, quarter },
                         courses: multiSearchData.map((params) => ({ ...params, department: params.deptValue })),
@@ -343,10 +343,10 @@ export default function CourseRenderPane(props: { id?: number }) {
                         if (offeredCoursesMapping[course.deptValue]?.has(course.courseNumber)) {
                             offeredCourses.push(getQueryParams(course));
                         } else {
-                            unofferedCourses.push(course);
+                            nextUnoffered.push(course);
                         }
                     }
-                    setUnofferedCourses(unofferedCourses);
+                    setUnofferedCourses(nextUnoffered);
                     response = await trpc.websoc.getMultiple.query({ params: offeredCourses });
                 } else {
                     const websocQueryParams = getQueryParams(RightPaneStore.getFormData());


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Three small react-doctor cleanups with no intended behavior change.

## Changes

1. **NotificationsTabs** — wrap `useState` initial tab in a lazy initializer so `sortedTerms.at(0)` is not re-evaluated every render.
2. **CourseRenderPane** — rename the local multi-search accumulator from `unofferedCourses` to `nextUnoffered` to avoid shadowing the state variable (silences a false-positive direct-mutation warning).
3. **DaySelector** — replace `.map().filter(Boolean)` with a single `.flatMap()` pass.

## Verification

- Targeted react-doctor rules (`rerender-lazy-state-init`, `no-direct-state-mutation`, `js-flatmap-filter`) no longer fire for these sites.
- Manual smoke: notifications tabs, custom event day picker, multi-course search with unoffered courses.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-efaa4906-5381-4f5c-b931-9f332bb295bc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-efaa4906-5381-4f5c-b931-9f332bb295bc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

