### PR TITLE
fix: remove unneeded schedule loaded snackbar

### DIFF
--- a/apps/antalmanac/src/actions/AppStoreActions.ts
+++ b/apps/antalmanac/src/actions/AppStoreActions.ts
@@ -300,14 +300,14 @@ export const loadGuestSchedule = async (username: string, rememberMe: boolean, p
                 const result = await trpc.schedule.getGuest.query({ username });
                 const scheduleSaveState = result.userData;
 
-                let error = false;
-
-                if (!(await AppStore.loadSchedule(scheduleSaveState))) {
+                if (await AppStore.loadSchedule(scheduleSaveState)) {
+                    logAnalytics(postHog, {
+                        category: analyticsEnum.auth,
+                        action: analyticsEnum.auth.actions.LOAD_SCHEDULE_LEGACY,
+                        customProps: { providerId: username, rememberMe },
+                    });
+                } else {
                     AppStore.loadFallbackSchedule(scheduleSaveState);
-                    error = true;
-                }
-
-                if (error) {
                     logAnalytics(postHog, {
                         category: analyticsEnum.auth,
                         action: analyticsEnum.auth.actions.LOAD_SCHEDULE_LEGACY_FAIL,
@@ -316,15 +316,9 @@ export const loadGuestSchedule = async (username: string, rememberMe: boolean, p
                     });
                     openSnackbar(
                         'error',
-                        `Network error loading course information for "${username}". 	              
+                        `Network error loading course information for "${username}".
                         If this continues to happen, please submit a feedback form.`
                     );
-                } else {
-                    logAnalytics(postHog, {
-                        category: analyticsEnum.auth,
-                        action: analyticsEnum.auth.actions.LOAD_SCHEDULE_LEGACY,
-                        customProps: { providerId: username, rememberMe },
-                    });
                 }
             } catch (e) {
                 logAnalytics(postHog, {

--- a/apps/antalmanac/src/actions/AppStoreActions.ts
+++ b/apps/antalmanac/src/actions/AppStoreActions.ts
@@ -302,9 +302,7 @@ export const loadGuestSchedule = async (username: string, rememberMe: boolean, p
 
                 let error = false;
 
-                if (await AppStore.loadSchedule(scheduleSaveState)) {
-                    openSnackbar('success', `Schedule loaded.`);
-                } else {
+                if (!(await AppStore.loadSchedule(scheduleSaveState))) {
                     AppStore.loadFallbackSchedule(scheduleSaveState);
                     error = true;
                 }
@@ -372,7 +370,6 @@ export const loadSchedule = async ({ prefetched, postHog }: LoadScheduleOptions)
         } else if (await AppStore.loadSchedule(scheduleSaveState)) {
             useHiddenCoursesStore.getState().hydrateFromSchedules(scheduleSaveState.schedules);
             analyticsIdentifyUser(postHog, userId);
-            openSnackbar('success', `Schedule loaded.`);
             logAnalytics(postHog, {
                 category: analyticsEnum.auth,
                 action: analyticsEnum.auth.actions.LOAD_SCHEDULE,


### PR DESCRIPTION
## Summary

Since we already can differentiate between loading and empty state, we no longer need to say that the schedule has loaded.

(this also brings scheduler in parity with planner, which doesn't have this snackbar)

<img width="400" alt="image" src="https://github.com/user-attachments/assets/656242f0-c527-483f-926f-52178fc96fa5" />

<img width="400" alt="image" src="https://github.com/user-attachments/assets/ef2df436-c227-453c-b22a-5135afdd8b0c" />

As such, this can go:
<img width="400" alt="image" src="https://github.com/user-attachments/assets/56c03780-2129-49cf-bb57-20ffd5b57ad6" />

In the mean time, this also refactors the if statement.

---

## Test Plan

Existing tests should pass. The refactoring maintains the same functional behavior while improving code structure. Manual testing of schedule loading flows (both success and failure cases) would verify the analytics events are still logged correctly and error messages display as expected.

https://claude.ai/code/session_01ExwEixuW5JcBwWg4HFojYR