### PR TITLE
fix: overflow GE

### DIFF
--- a/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/LabeledInputs/CustomInputBox.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/LabeledInputs/CustomInputBox.tsx
@@ -15,6 +15,7 @@ export const CustomInputBox = ({ children, boxProps }: CustomInputBoxProps) => {
         <Box
             {...boxProps}
             flexGrow={1}
+            minWidth={0}
             sx={{
                 '& .MuiOutlinedInput-root': {
                     minWidth: 100,


### PR DESCRIPTION
## Summary
Fix overflow on the General Education multi-select field when multiple GE categories are selected

<img width="443" height="477" alt="Screenshot 2026-05-28 at 8 21 47 AM" src="https://github.com/user-attachments/assets/0239318e-048d-4726-a629-9a5899606220" />

## Test Plan
- [ ]  Open the manual search form
- [ ]  Click the General Education dropdown and select multiple GE categories
- [ ]  Verify the selected value is truncated with an ellipsis instead of overflowing into the Section Code field

## Issues

Closes #1824 

<!-- [Optional]
## Future Followup
-->
