### PR TITLE
Extend auth sessions from 7 days to 30 days

### DIFF
--- a/apps/antalmanac/src/lib/auth/auth.ts
+++ b/apps/antalmanac/src/lib/auth/auth.ts
@@ -106,6 +106,7 @@ export const auth = betterAuth({
             token: 'refreshToken',
             expiresAt: 'expires',
         },
+        expiresIn: 30 * 24 * 60 * 60, // 30 days
         cookieCache: {
             enabled: true,
             maxAge: 5 * 60, // 5 minutes


### PR DESCRIPTION
## Summary

Change sessions to expire in 30 days instead of the default 7

## Test Plan

## Issues

Closes #

<!-- [Optional]
## Future Followup
-->
