### PR TITLE
fix: gate AddedCoursesList skeleton when schedule is empty

### DIFF
--- a/apps/antalmanac/src/components/RightPane/AddedCourses/AddedCoursesList.tsx
+++ b/apps/antalmanac/src/components/RightPane/AddedCourses/AddedCoursesList.tsx
@@ -22,10 +22,6 @@ export const AddedCoursesList = memo(({ courses, scheduleNames, onCourseOrderCha
     const setActiveTab = useTabStore((state) => state.setActiveTab);
     const setOpenImportDialog = useScheduleComponentsToggleStore((state) => state.setOpenImportDialog);
 
-    if (openLoadingSchedule) {
-        return <AddedCoursesLoadingSkeleton />;
-    }
-
     if (courses.length === 0) {
         return (
             <EmptyState
@@ -42,6 +38,10 @@ export const AddedCoursesList = memo(({ courses, scheduleNames, onCourseOrderCha
                 }}
             />
         );
+    }
+
+    if (openLoadingSchedule) {
+        return <AddedCoursesLoadingSkeleton />;
     }
 
     return (


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Addresses cubic-dev-ai feedback on PR #1879: the added-courses loading skeleton was shown whenever `openLoadingSchedule` was true, including on first load when the schedule has no courses. Because `openLoadingSchedule` defaults to `true` in `ScheduleComponentsToggleStore`, new users saw a skeleton instead of the "No Courses Added Yet" empty state.

Reordered checks in `AddedCoursesList` so the empty state renders when `courses.length === 0`, and the skeleton only appears when loading with existing courses (e.g. schedule import).

## Test Plan

- [ ] Open AntAlmanac with an empty schedule on first load: right pane shows empty state with Search/Import actions, not skeleton
- [ ] Import or load a schedule with courses while `openLoadingSchedule` is true: skeleton still shows until loading completes
- [ ] With courses present and loading finished: course list renders normally

## Issues

Related to PR #1879 review feedback.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-016c8f2a-62ab-41f4-a8c0-91a133ab1646"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-016c8f2a-62ab-41f4-a8c0-91a133ab1646"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

