### PR TITLE
fix: mobile calendar tab navigates to search from other tabs

### DIFF
--- a/apps/antalmanac/src/components/ScheduleManagement/ScheduleManagement.tsx
+++ b/apps/antalmanac/src/components/ScheduleManagement/ScheduleManagement.tsx
@@ -44,7 +44,6 @@ export function ScheduleManagement() {
      * Ref to the scrollable container with all of the tabs-content within it.
      */
     const ref = useRef<HTMLDivElement>(null);
-    const hasAppliedInitialTabRef = useRef(false);
 
     // Save the current scroll position to the store.
     const onScroll = (e: React.UIEvent<HTMLDivElement, UIEvent>) => {
@@ -71,19 +70,10 @@ export function ScheduleManagement() {
     );
 
     // Sync tab store when the route changes (back/forward, /added, /map).
+    // Calendar and search both live at `/`, so leave tab state alone for that route.
     useEffect(() => {
-        if (tab === 'added') {
-            hasAppliedInitialTabRef.current = true;
+        if (tab === 'added' || tab === 'map') {
             setActiveTab(tab);
-            return;
-        }
-        if (tab === 'map') {
-            hasAppliedInitialTabRef.current = true;
-            setActiveTab(tab);
-            return;
-        }
-        if (hasAppliedInitialTabRef.current) {
-            setActiveTab('search');
         }
     }, [tab, setActiveTab]);
 
@@ -114,8 +104,6 @@ export function ScheduleManagement() {
                 setActiveTab('search');
             }
         }
-
-        hasAppliedInitialTabRef.current = true;
 
         // NB: We disable exhaustive deps here as `tab` is a dependency, but we only want this effect to run on mount
         // eslint-disable-next-line react-hooks/exhaustive-deps


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes a mobile regression where tapping **Calendar** from **Added** or **Map** briefly switched to calendar, then immediately jumped back to **Search**.

## Root cause

Introduced in **#1817 (feat: nuqs, commit `7f945bfc9`, May 26 2026)**.

That PR split tab initialization into two effects. The new route-sync effect forced `setActiveTab('search')` whenever the URL was not `/added` or `/map`:

```tsx
if (hasAppliedInitialTabRef.current) {
    setActiveTab('search');
}
```

Calendar is mobile-only and shares `/` with Search (`href: ''` resolves to `/`). Clicking Calendar from another tab:

1. `handleTabChange` correctly sets `activeTab = calendar`
2. The tab `Link` navigates to `/`
3. The route-sync effect sees no `:tab` param and overrides back to Search

## Fix

Only sync tab state from the URL for routes that uniquely identify a tab (`/added`, `/map`). Leave tab state alone at `/`, where Calendar and Search are distinguished by Zustand state (same behavior as before #1817).

## Test plan

- [ ] On mobile, open **Added** or **Map**, tap **Calendar** → calendar view stays visible
- [ ] On mobile, tap **Search** from **Added**/**Map** → search view loads
- [ ] On mobile, tap **Added**/**Map** → correct tab content
- [ ] Desktop tab navigation unchanged
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01f16853-9d6a-4c05-9718-6c2bb85671c0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01f16853-9d6a-4c05-9718-6c2bb85671c0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

