### PR TITLE
refactor: type WebSOC days as a typed enum array

### DIFF
--- a/apps/antalmanac/src/backend/routers/websoc.ts
+++ b/apps/antalmanac/src/backend/routers/websoc.ts
@@ -19,10 +19,11 @@ import { z } from 'zod';
 import { router } from '../trpc';
 
 function sanitizeWebsocParams(params: WebsocSearchInput): WebsocQueryParams {
-    const { department, courseNumber, excludeRestrictionCodes, ...rest } = params;
+    const { department, courseNumber, excludeRestrictionCodes, days, ...rest } = params;
     const sanitized = {
         ...rest,
         excludeRestrictionCodes: excludeRestrictionCodes.join(','),
+        days: days.join(','),
     } as WebsocQueryParams;
 
     const normalizedDepartment = department?.toUpperCase();

--- a/apps/antalmanac/src/components/RightPane/CoursePane/CourseRenderPane/CourseRenderPane.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/CourseRenderPane/CourseRenderPane.tsx
@@ -68,7 +68,7 @@ export function CourseRenderPane({ onDismissSearchResults }: CourseRenderPanePro
             room: searchData.room,
             division: searchData.division,
             excludeRestrictionCodes: searchData.excludeRestrictionCodes,
-            days: searchData.days.split(/(?=[A-Z])/).join(','),
+            days: searchData.days,
         }),
         []
     );

--- a/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/ManualSearch/AdvancedSearch/AdvancedSearchFields/DaysField.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/ManualSearch/AdvancedSearch/AdvancedSearchFields/DaysField.tsx
@@ -2,29 +2,31 @@ import { LabeledSelect } from '$components/RightPane/CoursePane/SearchForm/Label
 import { DAYS_OPTIONS } from '$components/RightPane/CoursePane/SearchForm/ManualSearch/AdvancedSearch/constants';
 import { useCourseSearchParam } from '$components/RightPane/CoursePane/SearchParams/hooks';
 import { Checkbox, ListItemText, MenuItem, type SelectChangeEvent } from '@mui/material';
+import type { WebsocDayOption } from '@packages/antalmanac-types';
 import { memo } from 'react';
 
 export const DaysField = memo(() => {
     const [days, setDays] = useCourseSearchParam('days');
 
     return (
-        <LabeledSelect
+        <LabeledSelect<WebsocDayOption[]>
             label="Days"
             selectProps={{
                 multiple: true,
-                value: days ? days.split(/(?=[A-Z])/) : [],
-                onChange: (event: SelectChangeEvent<string | string[]>) => {
-                    const value = event.target.value;
-                    setDays(Array.isArray(value) ? value.join('') : value);
+                value: days,
+                onChange: (event: SelectChangeEvent<WebsocDayOption[]>) => {
+                    const { value } = event.target;
+                    if (Array.isArray(value)) {
+                        setDays(
+                            value.sort(
+                                (a, b) =>
+                                    DAYS_OPTIONS.findIndex((day) => day.value === a) -
+                                    DAYS_OPTIONS.findIndex((day) => day.value === b)
+                            )
+                        );
+                    }
                 },
-                renderValue: (selected) =>
-                    (selected as string[])
-                        .sort((a, b) => {
-                            const orderA = DAYS_OPTIONS.findIndex((day) => day.value === a);
-                            const orderB = DAYS_OPTIONS.findIndex((day) => day.value === b);
-                            return orderA - orderB;
-                        })
-                        .join(', '),
+                renderValue: (selected) => (selected as WebsocDayOption[]).join(', '),
                 sx: { width: '100%' },
             }}
         >

--- a/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/ManualSearch/AdvancedSearch/AdvancedSearchFields/DaysField.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/ManualSearch/AdvancedSearch/AdvancedSearchFields/DaysField.tsx
@@ -26,7 +26,7 @@ export const DaysField = memo(() => {
                         );
                     }
                 },
-                renderValue: (selected) => (selected as WebsocDayOption[]).join(', '),
+                renderValue: (selected) => selected.join(', '),
                 sx: { width: '100%' },
             }}
         >

--- a/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/ManualSearch/AdvancedSearch/AdvancedSearchFields/DaysField.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/ManualSearch/AdvancedSearch/AdvancedSearchFields/DaysField.tsx
@@ -3,6 +3,7 @@ import { DAYS_OPTIONS } from '$components/RightPane/CoursePane/SearchForm/Manual
 import { useCourseSearchParam } from '$components/RightPane/CoursePane/SearchParams/hooks';
 import { Checkbox, ListItemText, MenuItem, type SelectChangeEvent } from '@mui/material';
 import type { WebsocDayOption } from '@packages/antalmanac-types';
+import { WEBSOC_DAYS } from '@packages/antalmanac-types';
 import { memo } from 'react';
 
 export const DaysField = memo(() => {
@@ -17,13 +18,7 @@ export const DaysField = memo(() => {
                 onChange: (event: SelectChangeEvent<WebsocDayOption[]>) => {
                     const { value } = event.target;
                     if (Array.isArray(value)) {
-                        setDays(
-                            value.sort(
-                                (a, b) =>
-                                    DAYS_OPTIONS.findIndex((day) => day.value === a) -
-                                    DAYS_OPTIONS.findIndex((day) => day.value === b)
-                            )
-                        );
+                        setDays([...value].sort((a, b) => WEBSOC_DAYS.indexOf(a) - WEBSOC_DAYS.indexOf(b)));
                     }
                 },
                 renderValue: (selected) => selected.join(', '),

--- a/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/ManualSearch/AdvancedSearch/AdvancedSearchFields/DaysField.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/ManualSearch/AdvancedSearch/AdvancedSearchFields/DaysField.tsx
@@ -1,10 +1,15 @@
 import { LabeledSelect } from '$components/RightPane/CoursePane/SearchForm/LabeledInputs/LabeledSelect';
 import { DAYS_OPTIONS } from '$components/RightPane/CoursePane/SearchForm/ManualSearch/AdvancedSearch/constants';
 import { useCourseSearchParam } from '$components/RightPane/CoursePane/SearchParams/hooks';
+import { parseDaysString } from '$stores/calendarizeHelpers';
 import { Checkbox, ListItemText, MenuItem, type SelectChangeEvent } from '@mui/material';
 import type { WebsocDayOption } from '@packages/antalmanac-types';
 import { WEBSOC_DAYS } from '@packages/antalmanac-types';
 import { memo } from 'react';
+
+function sortWebsocDays(days: WebsocDayOption[]): WebsocDayOption[] {
+    return [...days].sort((a, b) => WEBSOC_DAYS.indexOf(a) - WEBSOC_DAYS.indexOf(b));
+}
 
 export const DaysField = memo(() => {
     const [days, setDays] = useCourseSearchParam('days');
@@ -15,10 +20,13 @@ export const DaysField = memo(() => {
             selectProps={{
                 multiple: true,
                 value: days,
-                onChange: (event: SelectChangeEvent<WebsocDayOption[]>) => {
+                onChange: (event: SelectChangeEvent<WebsocDayOption | WebsocDayOption[]>) => {
                     const { value } = event.target;
                     if (Array.isArray(value)) {
-                        setDays([...value].sort((a, b) => WEBSOC_DAYS.indexOf(a) - WEBSOC_DAYS.indexOf(b)));
+                        setDays(sortWebsocDays(value));
+                    } else if (typeof value === 'string') {
+                        const indices = parseDaysString(value);
+                        setDays(sortWebsocDays((indices ?? []).map((index) => WEBSOC_DAYS[index])));
                     }
                 },
                 renderValue: (selected) => selected.join(', '),

--- a/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/ManualSearch/AdvancedSearch/AdvancedSearchFields/DaysField.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/ManualSearch/AdvancedSearch/AdvancedSearchFields/DaysField.tsx
@@ -1,15 +1,10 @@
 import { LabeledSelect } from '$components/RightPane/CoursePane/SearchForm/LabeledInputs/LabeledSelect';
 import { DAYS_OPTIONS } from '$components/RightPane/CoursePane/SearchForm/ManualSearch/AdvancedSearch/constants';
 import { useCourseSearchParam } from '$components/RightPane/CoursePane/SearchParams/hooks';
-import { parseDaysString } from '$stores/calendarizeHelpers';
 import { Checkbox, ListItemText, MenuItem, type SelectChangeEvent } from '@mui/material';
 import type { WebsocDayOption } from '@packages/antalmanac-types';
 import { WEBSOC_DAYS } from '@packages/antalmanac-types';
 import { memo } from 'react';
-
-function sortWebsocDays(days: WebsocDayOption[]): WebsocDayOption[] {
-    return [...days].sort((a, b) => WEBSOC_DAYS.indexOf(a) - WEBSOC_DAYS.indexOf(b));
-}
 
 export const DaysField = memo(() => {
     const [days, setDays] = useCourseSearchParam('days');
@@ -20,13 +15,10 @@ export const DaysField = memo(() => {
             selectProps={{
                 multiple: true,
                 value: days,
-                onChange: (event: SelectChangeEvent<WebsocDayOption | WebsocDayOption[]>) => {
+                onChange: (event: SelectChangeEvent<WebsocDayOption[]>) => {
                     const { value } = event.target;
                     if (Array.isArray(value)) {
-                        setDays(sortWebsocDays(value));
-                    } else if (typeof value === 'string') {
-                        const indices = parseDaysString(value);
-                        setDays(sortWebsocDays((indices ?? []).map((index) => WEBSOC_DAYS[index])));
+                        setDays([...value].sort((a, b) => WEBSOC_DAYS.indexOf(a) - WEBSOC_DAYS.indexOf(b)));
                     }
                 },
                 renderValue: (selected) => selected.join(', '),

--- a/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/ManualSearch/AdvancedSearch/AdvancedSearchFields/ExcludeRestrictionsField.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/ManualSearch/AdvancedSearch/AdvancedSearchFields/ExcludeRestrictionsField.tsx
@@ -2,16 +2,8 @@ import { LabeledSelect } from '$components/RightPane/CoursePane/SearchForm/Label
 import { EXCLUDE_RESTRICTION_CODES_OPTIONS } from '$components/RightPane/CoursePane/SearchForm/ManualSearch/AdvancedSearch/constants';
 import { useCourseSearchParam } from '$components/RightPane/CoursePane/SearchParams/hooks';
 import { Checkbox, ListItemText, MenuItem, type SelectChangeEvent } from '@mui/material';
-import { WEBSOC_RESTRICTION_CODES, type WebsocRestrictionCodeOption } from '@packages/antalmanac-types';
+import type { WebsocRestrictionCodeOption } from '@packages/antalmanac-types';
 import { memo } from 'react';
-
-function parseRestrictionCodeSelection(value: string): WebsocRestrictionCodeOption[] {
-    const candidates = value.includes(',') ? value.split(',').map((code) => code.trim()) : [...value];
-
-    return candidates.filter((code): code is WebsocRestrictionCodeOption =>
-        (WEBSOC_RESTRICTION_CODES as readonly string[]).includes(code)
-    );
-}
 
 export const ExcludeRestrictionsField = memo(() => {
     const [excludeRestrictionCodes, setExcludeRestrictionCodes] = useCourseSearchParam('excludeRestrictionCodes');
@@ -22,12 +14,10 @@ export const ExcludeRestrictionsField = memo(() => {
             selectProps={{
                 multiple: true,
                 value: excludeRestrictionCodes,
-                onChange: (event: SelectChangeEvent<WebsocRestrictionCodeOption | WebsocRestrictionCodeOption[]>) => {
+                onChange: (event: SelectChangeEvent<WebsocRestrictionCodeOption[]>) => {
                     const { value } = event.target;
                     if (Array.isArray(value)) {
                         setExcludeRestrictionCodes(value);
-                    } else if (typeof value === 'string') {
-                        setExcludeRestrictionCodes(parseRestrictionCodeSelection(value));
                     }
                 },
                 renderValue: (selected) => selected.join(', '),

--- a/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/ManualSearch/AdvancedSearch/AdvancedSearchFields/ExcludeRestrictionsField.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/ManualSearch/AdvancedSearch/AdvancedSearchFields/ExcludeRestrictionsField.tsx
@@ -2,8 +2,16 @@ import { LabeledSelect } from '$components/RightPane/CoursePane/SearchForm/Label
 import { EXCLUDE_RESTRICTION_CODES_OPTIONS } from '$components/RightPane/CoursePane/SearchForm/ManualSearch/AdvancedSearch/constants';
 import { useCourseSearchParam } from '$components/RightPane/CoursePane/SearchParams/hooks';
 import { Checkbox, ListItemText, MenuItem, type SelectChangeEvent } from '@mui/material';
-import type { WebsocRestrictionCodeOption } from '@packages/antalmanac-types';
+import { WEBSOC_RESTRICTION_CODES, type WebsocRestrictionCodeOption } from '@packages/antalmanac-types';
 import { memo } from 'react';
+
+function parseRestrictionCodeSelection(value: string): WebsocRestrictionCodeOption[] {
+    const candidates = value.includes(',') ? value.split(',').map((code) => code.trim()) : [...value];
+
+    return candidates.filter((code): code is WebsocRestrictionCodeOption =>
+        (WEBSOC_RESTRICTION_CODES as readonly string[]).includes(code)
+    );
+}
 
 export const ExcludeRestrictionsField = memo(() => {
     const [excludeRestrictionCodes, setExcludeRestrictionCodes] = useCourseSearchParam('excludeRestrictionCodes');
@@ -14,10 +22,12 @@ export const ExcludeRestrictionsField = memo(() => {
             selectProps={{
                 multiple: true,
                 value: excludeRestrictionCodes,
-                onChange: (event: SelectChangeEvent<WebsocRestrictionCodeOption[]>) => {
+                onChange: (event: SelectChangeEvent<WebsocRestrictionCodeOption | WebsocRestrictionCodeOption[]>) => {
                     const { value } = event.target;
                     if (Array.isArray(value)) {
                         setExcludeRestrictionCodes(value);
+                    } else if (typeof value === 'string') {
+                        setExcludeRestrictionCodes(parseRestrictionCodeSelection(value));
                     }
                 },
                 renderValue: (selected) => selected.join(', '),

--- a/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/ManualSearch/AdvancedSearch/constants.ts
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/ManualSearch/AdvancedSearch/constants.ts
@@ -1,4 +1,4 @@
-import type { WebsocRestrictionCodeOption } from '@packages/antalmanac-types';
+import type { WebsocDayOption, WebsocRestrictionCodeOption } from '@packages/antalmanac-types';
 import type { WebsocDivisionOption, WebsocFullCoursesOption } from '@packages/anteater-api/types';
 
 export const DIVISION_OPTIONS = [
@@ -45,4 +45,4 @@ export const DAYS_OPTIONS = [
     { value: 'Th', label: 'Th: Thursday' },
     { value: 'F', label: 'F: Friday' },
     { value: 'Sa', label: 'Sa: Saturday' },
-];
+] as const satisfies readonly { value: WebsocDayOption; label: string }[];

--- a/apps/antalmanac/src/components/RightPane/CoursePane/SearchParams/defaults.ts
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/SearchParams/defaults.ts
@@ -1,6 +1,7 @@
 import { ANY_GE } from '$components/RightPane/CoursePane/SearchForm/constants';
 import { getDefaultTerm } from '$lib/term';
 import {
+    WebsocDayOptionSchema,
     WebsocDivisionOptionSchema,
     WebsocFullCoursesOptionSchema,
     WebsocRestrictionCodeOptionSchema,
@@ -26,7 +27,7 @@ export const DEFAULT_ADVANCED_SEARCH_VALUES = {
     division: WebsocDivisionOptionSchema.enum.ANY,
     excludeRoadmapCourses: '',
     excludeRestrictionCodes: [] satisfies (typeof WebsocRestrictionCodeOptionSchema.options)[number][],
-    days: '',
+    days: [] satisfies (typeof WebsocDayOptionSchema.options)[number][],
 };
 
 export const DEFAULT_FORM_DATA = {

--- a/apps/antalmanac/src/components/RightPane/CoursePane/SearchParams/parsers.ts
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/SearchParams/parsers.ts
@@ -12,6 +12,7 @@ import {
 } from '$components/RightPane/CoursePane/SearchParams/defaults';
 import { getTermByShortName } from '$lib/term';
 import {
+    WebsocDayOptionSchema,
     WebsocDivisionOptionSchema,
     WebsocFullCoursesOptionSchema,
     WebsocRestrictionCodeOptionSchema,
@@ -53,7 +54,9 @@ export const courseSearchParamParsers = {
     excludeRestrictionCodes: parseAsArrayOf(
         parseAsStringLiteral(WebsocRestrictionCodeOptionSchema.options)
     ).withDefault(DEFAULT_ADVANCED_SEARCH_VALUES.excludeRestrictionCodes),
-    days: parseAsString.withDefault(DEFAULT_ADVANCED_SEARCH_VALUES.days),
+    days: parseAsArrayOf(parseAsStringLiteral(WebsocDayOptionSchema.options)).withDefault(
+        DEFAULT_ADVANCED_SEARCH_VALUES.days
+    ),
 };
 
 export const advancedSearchParsers: Pick<typeof courseSearchParamParsers, AdvancedSearchParam> = {

--- a/apps/antalmanac/src/components/RightPane/SectionTable/GEDataFetchProvider.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/GEDataFetchProvider.tsx
@@ -34,7 +34,7 @@ const GeDataFetchProvider = (props: SectionTableProps) => {
             room: advanced.room,
             division: advanced.division,
             excludeRestrictionCodes: advanced.excludeRestrictionCodes,
-            days: advanced.days.split(/(?=[A-Z])/).join(','),
+            days: advanced.days,
         };
     }, [
         advanced,

--- a/apps/antalmanac/src/lib/utils.ts
+++ b/apps/antalmanac/src/lib/utils.ts
@@ -29,7 +29,7 @@ export function isNotEmpty<T>(array: T[]): array is [T, ...T[]] {
  * const indices = indicesOrNull.filter(notNull)
  * ```
  */
-export function getReferencesOccurring(reference: string[], input?: string | string[] | null): boolean[] {
+export function getReferencesOccurring(reference: readonly string[], input?: string | string[] | null): boolean[] {
     return input ? reference.map((reference) => input.includes(reference)) : reference.map(() => false);
 }
 

--- a/apps/antalmanac/src/stores/calendarizeHelpers.ts
+++ b/apps/antalmanac/src/stores/calendarizeHelpers.ts
@@ -4,7 +4,7 @@ import type { ScheduleCourse, RepeatingCustomEvent } from '@packages/antalmanac-
 import { WEBSOC_DAYS } from '@packages/antalmanac-types';
 import type { HourMinute } from '@packages/anteater-api/types';
 
-export const SHORT_DAYS: string[] = [...WEBSOC_DAYS];
+export const COURSE_WEEK_DAYS: string[] = [...WEBSOC_DAYS];
 
 const FINALS_WEEK_DAYS = ['Sat', 'Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri'];
 
@@ -29,7 +29,7 @@ function mapLocationsWithDay(bldg: string[], dayIndex: number, includeDays: bool
         const location = getLocation(bldgEntry);
         locations.push({
             ...location,
-            ...(includeDays && { days: SHORT_DAYS[dayIndex] }),
+            ...(includeDays && { days: COURSE_WEEK_DAYS[dayIndex] }),
         });
     }
     return locations;
@@ -55,7 +55,7 @@ export const calendarizeCourseEvents = (currentCourses: ScheduleCourse[] = []): 
              *
              * @example [false, true, false, true, false, true, false], i.e. [M, W, F]
              */
-            const daysOccurring = getReferencesOccurring(SHORT_DAYS, meeting.days);
+            const daysOccurring = getReferencesOccurring(COURSE_WEEK_DAYS, meeting.days);
 
             /**
              * Only include the day indices that the meeting occurs.
@@ -155,7 +155,7 @@ export function calendarizeFinals(currentCourses: ScheduleCourse[] = []): Course
                 locations: locationsWithNoDays.map((location: Location) => {
                     return {
                         ...location,
-                        days: SHORT_DAYS[dayIndex],
+                        days: COURSE_WEEK_DAYS[dayIndex],
                     };
                 }),
                 showLocationInfo: true,
@@ -187,7 +187,7 @@ export function calendarizeCustomEvents(currentCustomEvents: RepeatingCustomEven
         if (isNaN(startHour) || isNaN(startMin) || isNaN(endHour) || isNaN(endMin)) return [];
 
         const dayIndicesOccurring = getDayIndicesOccurring(customEvent.days);
-        const days = dayIndicesOccurring.map((dayIndex) => SHORT_DAYS[dayIndex]);
+        const days = dayIndicesOccurring.map((dayIndex) => COURSE_WEEK_DAYS[dayIndex]);
 
         return dayIndicesOccurring.map((dayIndex) => {
             return {
@@ -204,7 +204,7 @@ export function calendarizeCustomEvents(currentCustomEvents: RepeatingCustomEven
     });
 }
 
-const SHORT_DAY_REGEX = new RegExp(`(${SHORT_DAYS.join('|')})`, 'g');
+const SHORT_DAY_REGEX = new RegExp(`(${COURSE_WEEK_DAYS.join('|')})`, 'g');
 
 /**
  * Parses a day string into an array of numbers.
@@ -225,7 +225,7 @@ export function parseDaysString(daysString: string | null): number[] | null {
     let match: RegExpExecArray | null;
 
     while ((match = SHORT_DAY_REGEX.exec(daysString))) {
-        days.push(SHORT_DAYS.indexOf(match[1]));
+        days.push(COURSE_WEEK_DAYS.indexOf(match[1]));
     }
 
     return days;

--- a/apps/antalmanac/src/stores/calendarizeHelpers.ts
+++ b/apps/antalmanac/src/stores/calendarizeHelpers.ts
@@ -1,9 +1,10 @@
 import type { CourseEvent, CustomEvent, FinalExam, Location } from '$components/Calendar/types';
 import { getReferencesOccurring } from '$lib/utils';
 import type { ScheduleCourse, RepeatingCustomEvent } from '@packages/antalmanac-types';
+import { WEBSOC_DAYS } from '@packages/antalmanac-types';
 import type { HourMinute } from '@packages/anteater-api/types';
 
-const COURSE_WEEK_DAYS = ['Su', 'M', 'Tu', 'W', 'Th', 'F', 'Sa'];
+const COURSE_WEEK_DAYS: string[] = [...WEBSOC_DAYS];
 
 const FINALS_WEEK_DAYS = ['Sat', 'Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri'];
 
@@ -203,7 +204,7 @@ export function calendarizeCustomEvents(currentCustomEvents: RepeatingCustomEven
     });
 }
 
-export const SHORT_DAYS = ['Su', 'M', 'Tu', 'W', 'Th', 'F', 'Sa'];
+export const SHORT_DAYS: string[] = [...WEBSOC_DAYS];
 
 const SHORT_DAY_REGEX = new RegExp(`(${SHORT_DAYS.join('|')})`, 'g');
 

--- a/apps/antalmanac/src/stores/calendarizeHelpers.ts
+++ b/apps/antalmanac/src/stores/calendarizeHelpers.ts
@@ -4,7 +4,7 @@ import type { ScheduleCourse, RepeatingCustomEvent } from '@packages/antalmanac-
 import { WEBSOC_DAYS } from '@packages/antalmanac-types';
 import type { HourMinute } from '@packages/anteater-api/types';
 
-const COURSE_WEEK_DAYS: string[] = [...WEBSOC_DAYS];
+export const SHORT_DAYS: string[] = [...WEBSOC_DAYS];
 
 const FINALS_WEEK_DAYS = ['Sat', 'Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri'];
 
@@ -29,7 +29,7 @@ function mapLocationsWithDay(bldg: string[], dayIndex: number, includeDays: bool
         const location = getLocation(bldgEntry);
         locations.push({
             ...location,
-            ...(includeDays && { days: COURSE_WEEK_DAYS[dayIndex] }),
+            ...(includeDays && { days: SHORT_DAYS[dayIndex] }),
         });
     }
     return locations;
@@ -55,7 +55,7 @@ export const calendarizeCourseEvents = (currentCourses: ScheduleCourse[] = []): 
              *
              * @example [false, true, false, true, false, true, false], i.e. [M, W, F]
              */
-            const daysOccurring = getReferencesOccurring(COURSE_WEEK_DAYS, meeting.days);
+            const daysOccurring = getReferencesOccurring(SHORT_DAYS, meeting.days);
 
             /**
              * Only include the day indices that the meeting occurs.
@@ -155,7 +155,7 @@ export function calendarizeFinals(currentCourses: ScheduleCourse[] = []): Course
                 locations: locationsWithNoDays.map((location: Location) => {
                     return {
                         ...location,
-                        days: COURSE_WEEK_DAYS[dayIndex],
+                        days: SHORT_DAYS[dayIndex],
                     };
                 }),
                 showLocationInfo: true,
@@ -187,7 +187,7 @@ export function calendarizeCustomEvents(currentCustomEvents: RepeatingCustomEven
         if (isNaN(startHour) || isNaN(startMin) || isNaN(endHour) || isNaN(endMin)) return [];
 
         const dayIndicesOccurring = getDayIndicesOccurring(customEvent.days);
-        const days = dayIndicesOccurring.map((dayIndex) => COURSE_WEEK_DAYS[dayIndex]);
+        const days = dayIndicesOccurring.map((dayIndex) => SHORT_DAYS[dayIndex]);
 
         return dayIndicesOccurring.map((dayIndex) => {
             return {
@@ -203,8 +203,6 @@ export function calendarizeCustomEvents(currentCustomEvents: RepeatingCustomEven
         });
     });
 }
-
-export const SHORT_DAYS: string[] = [...WEBSOC_DAYS];
 
 const SHORT_DAY_REGEX = new RegExp(`(${SHORT_DAYS.join('|')})`, 'g');
 

--- a/apps/antalmanac/src/stores/calendarizeHelpers.ts
+++ b/apps/antalmanac/src/stores/calendarizeHelpers.ts
@@ -4,7 +4,7 @@ import type { ScheduleCourse, RepeatingCustomEvent } from '@packages/antalmanac-
 import { WEBSOC_DAYS } from '@packages/antalmanac-types';
 import type { HourMinute } from '@packages/anteater-api/types';
 
-export const COURSE_WEEK_DAYS: string[] = [...WEBSOC_DAYS];
+export const COURSE_WEEK_DAYS = WEBSOC_DAYS;
 
 const FINALS_WEEK_DAYS = ['Sat', 'Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri'];
 
@@ -225,7 +225,8 @@ export function parseDaysString(daysString: string | null): number[] | null {
     let match: RegExpExecArray | null;
 
     while ((match = SHORT_DAY_REGEX.exec(daysString))) {
-        days.push(COURSE_WEEK_DAYS.indexOf(match[1]));
+        const matchedDay = match[1];
+        days.push(COURSE_WEEK_DAYS.findIndex((day) => day === matchedDay));
     }
 
     return days;

--- a/apps/antalmanac/tests/parse-days-string.test.ts
+++ b/apps/antalmanac/tests/parse-days-string.test.ts
@@ -1,5 +1,5 @@
+import { parseDaysString, COURSE_WEEK_DAYS } from '$stores/calendarizeHelpers';
 import { describe, test, expect } from 'vitest';
-import { parseDaysString, SHORT_DAYS } from '$stores/calendarizeHelpers';
 
 describe('parse days string', () => {
     // This is a hardcoded example.
@@ -17,27 +17,30 @@ describe('parse days string', () => {
     // TODO: it might be possible to do all these tests with a single for loop.
 
     test('one day', () => {
-        for (const day of SHORT_DAYS) {
-            expect(parseDaysString(day)).toEqual([SHORT_DAYS.indexOf(day)]);
+        for (const day of COURSE_WEEK_DAYS) {
+            expect(parseDaysString(day)).toEqual([COURSE_WEEK_DAYS.indexOf(day)]);
         }
     });
 
     test('two days', () => {
-        for (const day1 of SHORT_DAYS) {
-            for (const day2 of SHORT_DAYS) {
-                expect(parseDaysString(`${day1}${day2}`)).toEqual([SHORT_DAYS.indexOf(day1), SHORT_DAYS.indexOf(day2)]);
+        for (const day1 of COURSE_WEEK_DAYS) {
+            for (const day2 of COURSE_WEEK_DAYS) {
+                expect(parseDaysString(`${day1}${day2}`)).toEqual([
+                    COURSE_WEEK_DAYS.indexOf(day1),
+                    COURSE_WEEK_DAYS.indexOf(day2),
+                ]);
             }
         }
     });
 
     test('three days', () => {
-        for (const day1 of SHORT_DAYS) {
-            for (const day2 of SHORT_DAYS) {
-                for (const day3 of SHORT_DAYS) {
+        for (const day1 of COURSE_WEEK_DAYS) {
+            for (const day2 of COURSE_WEEK_DAYS) {
+                for (const day3 of COURSE_WEEK_DAYS) {
                     expect(parseDaysString(`${day1}${day2}${day3}`)).toEqual([
-                        SHORT_DAYS.indexOf(day1),
-                        SHORT_DAYS.indexOf(day2),
-                        SHORT_DAYS.indexOf(day3),
+                        COURSE_WEEK_DAYS.indexOf(day1),
+                        COURSE_WEEK_DAYS.indexOf(day2),
+                        COURSE_WEEK_DAYS.indexOf(day3),
                     ]);
                 }
             }
@@ -45,15 +48,15 @@ describe('parse days string', () => {
     });
 
     test('four days', () => {
-        for (const day1 of SHORT_DAYS) {
-            for (const day2 of SHORT_DAYS) {
-                for (const day3 of SHORT_DAYS) {
-                    for (const day4 of SHORT_DAYS) {
+        for (const day1 of COURSE_WEEK_DAYS) {
+            for (const day2 of COURSE_WEEK_DAYS) {
+                for (const day3 of COURSE_WEEK_DAYS) {
+                    for (const day4 of COURSE_WEEK_DAYS) {
                         expect(parseDaysString(`${day1}${day2}${day3}${day4}`)).toEqual([
-                            SHORT_DAYS.indexOf(day1),
-                            SHORT_DAYS.indexOf(day2),
-                            SHORT_DAYS.indexOf(day3),
-                            SHORT_DAYS.indexOf(day4),
+                            COURSE_WEEK_DAYS.indexOf(day1),
+                            COURSE_WEEK_DAYS.indexOf(day2),
+                            COURSE_WEEK_DAYS.indexOf(day3),
+                            COURSE_WEEK_DAYS.indexOf(day4),
                         ]);
                     }
                 }
@@ -62,21 +65,24 @@ describe('parse days string', () => {
     });
 
     test('two days scrambled order', () => {
-        for (const day1 of SHORT_DAYS) {
-            for (const day2 of SHORT_DAYS) {
-                expect(parseDaysString(`${day2}${day1}`)).toEqual([SHORT_DAYS.indexOf(day2), SHORT_DAYS.indexOf(day1)]);
+        for (const day1 of COURSE_WEEK_DAYS) {
+            for (const day2 of COURSE_WEEK_DAYS) {
+                expect(parseDaysString(`${day2}${day1}`)).toEqual([
+                    COURSE_WEEK_DAYS.indexOf(day2),
+                    COURSE_WEEK_DAYS.indexOf(day1),
+                ]);
             }
         }
     });
 
     test('three days scrambled order', () => {
-        for (const day1 of SHORT_DAYS) {
-            for (const day2 of SHORT_DAYS) {
-                for (const day3 of SHORT_DAYS) {
+        for (const day1 of COURSE_WEEK_DAYS) {
+            for (const day2 of COURSE_WEEK_DAYS) {
+                for (const day3 of COURSE_WEEK_DAYS) {
                     expect(parseDaysString(`${day2}${day3}${day1}`)).toEqual([
-                        SHORT_DAYS.indexOf(day2),
-                        SHORT_DAYS.indexOf(day3),
-                        SHORT_DAYS.indexOf(day1),
+                        COURSE_WEEK_DAYS.indexOf(day2),
+                        COURSE_WEEK_DAYS.indexOf(day3),
+                        COURSE_WEEK_DAYS.indexOf(day1),
                     ]);
                 }
             }
@@ -84,15 +90,15 @@ describe('parse days string', () => {
     });
 
     test('four days scrambled order', () => {
-        for (const day1 of SHORT_DAYS) {
-            for (const day2 of SHORT_DAYS) {
-                for (const day3 of SHORT_DAYS) {
-                    for (const day4 of SHORT_DAYS) {
+        for (const day1 of COURSE_WEEK_DAYS) {
+            for (const day2 of COURSE_WEEK_DAYS) {
+                for (const day3 of COURSE_WEEK_DAYS) {
+                    for (const day4 of COURSE_WEEK_DAYS) {
                         expect(parseDaysString(`${day4}${day3}${day1}${day2}`)).toEqual([
-                            SHORT_DAYS.indexOf(day4),
-                            SHORT_DAYS.indexOf(day3),
-                            SHORT_DAYS.indexOf(day1),
-                            SHORT_DAYS.indexOf(day2),
+                            COURSE_WEEK_DAYS.indexOf(day4),
+                            COURSE_WEEK_DAYS.indexOf(day3),
+                            COURSE_WEEK_DAYS.indexOf(day1),
+                            COURSE_WEEK_DAYS.indexOf(day2),
                         ]);
                     }
                 }

--- a/packages/types/src/websoc.ts
+++ b/packages/types/src/websoc.ts
@@ -78,6 +78,11 @@ export const WEBSOC_RESTRICTION_CODES = [
 export const WebsocRestrictionCodeOptionSchema = z.enum(WEBSOC_RESTRICTION_CODES);
 export type WebsocRestrictionCodeOption = z.infer<typeof WebsocRestrictionCodeOptionSchema>;
 
+/** UCI WebSoc day abbreviations (Su, M, Tu, W, Th, F, Sa). */
+export const WEBSOC_DAYS = ['Su', 'M', 'Tu', 'W', 'Th', 'F', 'Sa'] as const;
+export const WebsocDayOptionSchema = z.enum(WEBSOC_DAYS);
+export type WebsocDayOption = z.infer<typeof WebsocDayOptionSchema>;
+
 export const WebsocSearchInputSchema = z.object({
     year: z.string(),
     quarter: QuarterSchema,
@@ -87,7 +92,7 @@ export const WebsocSearchInputSchema = z.object({
     courseTitle: z.string().optional(),
     sectionCodes: z.string().optional(),
     instructorName: z.string().optional(),
-    days: z.string().optional(),
+    days: z.array(WebsocDayOptionSchema).default([]),
     building: z.string().optional(),
     room: z.string().optional(),
     division: WebsocDivisionOptionSchema.optional(),
@@ -106,9 +111,10 @@ export const WebsocSearchInputSchema = z.object({
                 ? string | WebsocQueryParams[K]
                 : WebsocQueryParams[K];
         },
-        'excludeRestrictionCodes'
+        'excludeRestrictionCodes' | 'days'
     > & {
         excludeRestrictionCodes?: WebsocRestrictionCodeOption[];
+        days?: WebsocDayOption[];
     }
 >;
 export type WebsocSearchInput = z.infer<typeof WebsocSearchInputSchema>;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up to #1884: add `WEBSOC_DAYS` and `WebsocDayOptionSchema` in `@packages/antalmanac-types` as the shared source of truth for WebSOC day abbreviations (`Su`, `M`, `Tu`, `W`, `Th`, `F`, `Sa`).

- `WebsocSearchInput.days` is now `WebsocDayOption[]` (default `[]`) instead of an optional string
- Advanced search URL params use `parseAsArrayOf(parseAsStringLiteral(...))`, matching exclude restriction codes
- `DaysField` works with a typed array and no longer splits/joins day strings manually
- `sanitizeWebsocParams` joins the array to a comma-separated string for the WebSOC API
- App-specific labels remain in `DAYS_OPTIONS` with `satisfies readonly { value: WebsocDayOption; label: string }[]`
- `calendarizeHelpers` derives `SHORT_DAYS` from `WEBSOC_DAYS` to avoid duplicating day keys

## Test Plan

- [x] `pnpm test --run apps/antalmanac/tests/parse-days-string.test.ts`
- [x] `pnpm lint`
- [x] Typecheck changed files (no new errors in touched modules)

## Issues

Closes #
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6733eceb-902d-4433-b263-c049b692bff7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6733eceb-902d-4433-b263-c049b692bff7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

