### PR TITLE
Revert "fix: gate AddedCoursesList skeleton when schedule is empty"

### DIFF
--- a/apps/antalmanac/src/components/RightPane/AddedCourses/AddedCoursesList.tsx
+++ b/apps/antalmanac/src/components/RightPane/AddedCourses/AddedCoursesList.tsx
@@ -22,6 +22,10 @@ export const AddedCoursesList = memo(({ courses, scheduleNames, onCourseOrderCha
     const setActiveTab = useTabStore((state) => state.setActiveTab);
     const setOpenImportDialog = useScheduleComponentsToggleStore((state) => state.setOpenImportDialog);
 
+    if (openLoadingSchedule) {
+        return <AddedCoursesLoadingSkeleton />;
+    }
+
     if (courses.length === 0) {
         return (
             <EmptyState
@@ -38,10 +42,6 @@ export const AddedCoursesList = memo(({ courses, scheduleNames, onCourseOrderCha
                 }}
             />
         );
-    }
-
-    if (openLoadingSchedule) {
-        return <AddedCoursesLoadingSkeleton />;
     }
 
     return (


### PR DESCRIPTION
The added course skeleton broke after #1881 (at least on prod with my schedule), as it displays the "no courses added" before skipping to my loaded courses.


Reverts icssc/AntAlmanac#1881