### PR TITLE
fix(theme): preserve system preference when OS appearance changes

### DIFF
--- a/apps/antalmanac/src/app/Theme.tsx
+++ b/apps/antalmanac/src/app/Theme.tsx
@@ -5,9 +5,7 @@ import { useThemeStore } from '$stores/SettingsStore';
 import { CssBaseline, type PaletteOptions } from '@mui/material';
 import { createTheme, ThemeProvider } from '@mui/material/styles';
 import { Roboto } from 'next/font/google';
-import { usePostHog } from 'posthog-js/react';
 import { useEffect, useMemo } from 'react';
-import { useShallow } from 'zustand/react/shallow';
 
 const roboto = Roboto({
     weight: ['300', '400', '500', '700'],
@@ -120,12 +118,12 @@ declare module '@mui/material/styles' {
  * sets and provides the MUI theme for the app
  */
 export default function AppThemeProvider(props: Props) {
-    const [isDark, setAppTheme] = useThemeStore(useShallow((store) => [store.isDark, store.setAppTheme]));
-    const postHog = usePostHog();
+    const isDark = useThemeStore((store) => store.isDark);
+    const syncSystemTheme = useThemeStore((store) => store.syncSystemTheme);
 
     useEffect(() => {
         const onChange = (e: MediaQueryListEvent) => {
-            setAppTheme(e.matches ? 'dark' : 'light', postHog);
+            syncSystemTheme(e.matches);
         };
 
         const mediaQueryList = window.matchMedia('(prefers-color-scheme: dark)');
@@ -135,7 +133,7 @@ export default function AppThemeProvider(props: Props) {
         return () => {
             mediaQueryList.removeEventListener('change', onChange);
         };
-    }, [setAppTheme, postHog]);
+    }, [syncSystemTheme]);
 
     const theme = useMemo(
         () =>

--- a/apps/antalmanac/src/app/Theme.tsx
+++ b/apps/antalmanac/src/app/Theme.tsx
@@ -6,6 +6,7 @@ import { CssBaseline, type PaletteOptions } from '@mui/material';
 import { createTheme, ThemeProvider } from '@mui/material/styles';
 import { Roboto } from 'next/font/google';
 import { useEffect, useMemo } from 'react';
+import { useShallow } from 'zustand/react/shallow';
 
 const roboto = Roboto({
     weight: ['300', '400', '500', '700'],
@@ -118,8 +119,7 @@ declare module '@mui/material/styles' {
  * sets and provides the MUI theme for the app
  */
 export default function AppThemeProvider(props: Props) {
-    const isDark = useThemeStore((store) => store.isDark);
-    const syncSystemTheme = useThemeStore((store) => store.syncSystemTheme);
+    const [isDark, syncSystemTheme] = useThemeStore(useShallow((store) => [store.isDark, store.syncSystemTheme]));
 
     useEffect(() => {
         const onChange = (e: MediaQueryListEvent) => {

--- a/apps/antalmanac/src/stores/SettingsStore.ts
+++ b/apps/antalmanac/src/stores/SettingsStore.ts
@@ -27,7 +27,6 @@ interface ThemeStore {
     isDark: boolean;
 
     setAppTheme: (themeSetting: ThemeSetting, postHog?: PostHog) => void;
-    /** Updates appearance when OS theme changes; only applies while themeSetting is 'system'. */
     syncSystemTheme: (isDark: boolean) => void;
 }
 

--- a/apps/antalmanac/src/stores/SettingsStore.ts
+++ b/apps/antalmanac/src/stores/SettingsStore.ts
@@ -27,6 +27,8 @@ interface ThemeStore {
     isDark: boolean;
 
     setAppTheme: (themeSetting: ThemeSetting, postHog?: PostHog) => void;
+    /** Updates appearance when OS theme changes; only applies while themeSetting is 'system'. */
+    syncSystemTheme: (isDark: boolean) => void;
 }
 
 function themeShouldBeDark(themeSetting: ThemeSetting) {
@@ -38,7 +40,7 @@ function themeShouldBeDark(themeSetting: ThemeSetting) {
     return themeSetting == 'dark';
 }
 
-export const useThemeStore = create<ThemeStore>((set) => {
+export const useThemeStore = create<ThemeStore>((set, get) => {
     const storedThemeSetting: ThemeSetting = ((typeof Storage !== 'undefined' ? getLocalStorageTheme() : null) ??
         'system') as ThemeSetting;
     const isDark = themeShouldBeDark(storedThemeSetting);
@@ -61,6 +63,13 @@ export const useThemeStore = create<ThemeStore>((set) => {
                     themeSetting,
                 },
             });
+        },
+
+        syncSystemTheme: (isDark) => {
+            if (get().themeSetting !== 'system') {
+                return;
+            }
+            set({ isDark });
         },
     };
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

When the user selects **System** theme, OS light/dark changes were calling `setAppTheme('light' | 'dark')`, which persisted that choice and switched the Settings UI away from **System**.

## Fix

- Add `syncSystemTheme(isDark)` on the theme store — only updates `isDark` when `themeSetting === 'system'`.
- `AppThemeProvider` uses `syncSystemTheme` for the `prefers-color-scheme` listener instead of `setAppTheme`.

## Testing

- [ ] Select **System**, change OS appearance → Settings still shows **System**, app follows OS.
- [ ] Select **Dark**, change OS → stays **Dark**.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8336d96c-a474-4c27-b8e2-c5303d237da1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8336d96c-a474-4c27-b8e2-c5303d237da1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

