### PR TITLE
feat(db): validate DB_URL with T3 Env

### DIFF
--- a/apps/antalmanac/src/generated/deployed_terms.json
+++ b/apps/antalmanac/src/generated/deployed_terms.json
@@ -1,6 +1,6 @@
 {
   "latestTerm": "2026 Fall Quarter",
-  "sectionCount": 12917,
-  "updatedAt": "2026-06-03T23:27:39.551Z",
+  "sectionCount": 12919,
+  "updatedAt": "2026-06-04T02:52:28.146Z",
   "reason": "Section count changed"
 }

--- a/packages/db/drizzle.config.ts
+++ b/packages/db/drizzle.config.ts
@@ -1,10 +1,12 @@
 import { defineConfig } from 'drizzle-kit';
 
+import { env } from './src/env';
+
 export default defineConfig({
     dialect: 'postgresql',
     schema: './src/schema/index.ts',
     out: './migrations',
     dbCredentials: {
-        url: process.env.DB_URL!,
+        url: env.DB_URL,
     },
 });

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -10,8 +10,10 @@
     },
     "dependencies": {
         "@paralleldrive/cuid2": "^2.2.2",
+        "@t3-oss/env-core": "0.13.11",
         "drizzle-orm": "^0.45.2",
-        "pg": "^8.16.3"
+        "pg": "^8.16.3",
+        "zod": "3.24.3"
     },
     "devDependencies": {
         "@types/pg": "^8.15.6",

--- a/packages/db/src/env.ts
+++ b/packages/db/src/env.ts
@@ -1,0 +1,19 @@
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { createEnv } from '@t3-oss/env-core';
+import { config } from 'dotenv';
+import { z } from 'zod';
+
+const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+config({ path: resolve(packageRoot, '.env') });
+
+export const env = createEnv({
+    server: {
+        DB_URL: z.string().min(1),
+    },
+    runtimeEnv: {
+        DB_URL: process.env.DB_URL,
+    },
+    emptyStringAsUndefined: true,
+});

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -1,11 +1,11 @@
-import 'dotenv/config';
 import { drizzle } from 'drizzle-orm/node-postgres';
 import { Pool } from 'pg';
 
+import { env } from './env';
 import * as schema from './schema/index';
 
 const pool = new Pool({
-    connectionString: process.env.DB_URL,
+    connectionString: env.DB_URL,
     max: 10,
     idleTimeoutMillis: 10000,
     connectionTimeoutMillis: 5000,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -334,12 +334,18 @@ importers:
       '@paralleldrive/cuid2':
         specifier: ^2.2.2
         version: 2.2.2
+      '@t3-oss/env-core':
+        specifier: 0.13.11
+        version: 0.13.11(typescript@5.9.3)(zod@3.24.3)
       drizzle-orm:
         specifier: ^0.45.2
         version: 0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.15.6)(gel@2.2.0)(knex@0.8.6)(kysely@0.28.17)(pg@8.16.3)(postgres@3.4.5)
       pg:
         specifier: ^8.16.3
         version: 8.16.3
+      zod:
+        specifier: 3.24.3
+        version: 3.24.3
     devDependencies:
       '@types/pg':
         specifier: ^8.15.6
@@ -3040,6 +3046,23 @@ packages:
 
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
+
+  '@t3-oss/env-core@0.13.11':
+    resolution: {integrity: sha512-sM7GYY+KL7H/Hl0BE0inWfk3nRHZOLhmVn7sHGxaZt9FAR6KqREXAE+6TqKfiavfXmpRxO/OZ2QgKRd+oiBYRQ==}
+    peerDependencies:
+      arktype: ^2.1.0
+      typescript: '>=5.0.0'
+      valibot: ^1.0.0-beta.7 || ^1.0.0
+      zod: ^3.24.0 || ^4.0.0
+    peerDependenciesMeta:
+      arktype:
+        optional: true
+      typescript:
+        optional: true
+      valibot:
+        optional: true
+      zod:
+        optional: true
 
   '@tanstack/query-core@5.100.9':
     resolution: {integrity: sha512-SJSFw1S8+kQ0+knv/XGfrbocWoAlT7vDKsSImtLx3ZPQmEcR46hkDjLSvynSy25N8Ms4tIEini1FuBd5k7IscQ==}
@@ -6267,6 +6290,7 @@ packages:
 
   uuid@8.0.0:
     resolution: {integrity: sha512-jOXGuXZAWdsTH7eZLtyXMqUb9EcWMGZNbL9YcGBJl4MH4nrxHmZJhEHvyLFrkxo+28uLb/NYRcStH48fnD0Vzw==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   v8flags@2.1.1:
@@ -6562,6 +6586,9 @@ packages:
 
   zod@3.24.2:
     resolution: {integrity: sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ==}
+
+  zod@3.24.3:
+    resolution: {integrity: sha512-HhY1oqzWCQWuUqvBFnsyrtZRhyPeR7SUGv+C4+MsisMuVfSPx8HpwWqH8tRahSlt6M3PiFAcoeFhZAqIXTxoSg==}
 
   zod@4.4.3:
     resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
@@ -9368,6 +9395,11 @@ snapshots:
   '@swc/helpers@0.5.15':
     dependencies:
       tslib: 2.8.1
+
+  '@t3-oss/env-core@0.13.11(typescript@5.9.3)(zod@3.24.3)':
+    optionalDependencies:
+      typescript: 5.9.3
+      zod: 3.24.3
 
   '@tanstack/query-core@5.100.9': {}
 
@@ -13198,6 +13230,8 @@ snapshots:
   zod@3.23.8: {}
 
   zod@3.24.2: {}
+
+  zod@3.24.3: {}
 
   zod@4.4.3: {}
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Step 4 of #1885: add T3 Env validation for `@packages/db`.

## Changes

- Add `@t3-oss/env-core` and `zod@3.24.3` to `packages/db`
- New `packages/db/src/env.ts` — validates `DB_URL` with `emptyStringAsUndefined`
- `src/index.ts` and `drizzle.config.ts` use `env.DB_URL` instead of raw `process.env`
- Load `packages/db/.env` from the package root (so `pnpm db:migrate` works when cwd is `packages/db`; app-level `DB_URL` from Next/SST is still respected when already set)

## Test plan

- [x] `pnpm lint`
- [ ] `pnpm db:migrate` with `packages/db/.env` configured

## Follow-up

- `apps/antalmanac` single `src/env.ts` (does not extend this module per plan)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bb196e26-a7cb-4b40-8ce9-4b2943aa06c3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bb196e26-a7cb-4b40-8ce9-4b2943aa06c3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

