### PR TITLE
fix: wire BETTER_AUTH_SECRET and warn on missing planner key

### DIFF
--- a/apps/antalmanac/src/backend/routers/roadmap.ts
+++ b/apps/antalmanac/src/backend/routers/roadmap.ts
@@ -41,6 +41,7 @@ const roadmapRouter = router({
 
         const apiKey = env.PLANNER_CLIENT_API_KEY;
         if (!apiKey) {
+            console.warn('PLANNER_CLIENT_API_KEY is not set; skipping planner roadmap fetch');
             return [];
         }
         const domain = (await headers()).get('host') ?? 'antalmanac.com';

--- a/apps/antalmanac/src/lib/auth/auth.ts
+++ b/apps/antalmanac/src/lib/auth/auth.ts
@@ -12,6 +12,7 @@ import { genericOAuth } from 'better-auth/plugins';
 
 export const auth = betterAuth({
     appName: 'AntAlmanac',
+    secret: env.BETTER_AUTH_SECRET,
     baseURL: env.BETTER_AUTH_URL,
     database: drizzleAdapter(db, { provider: 'pg', usePlural: true }),
     plugins: [


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Small follow-up to #1891 (T3 Env migration):

- Pass `secret: env.BETTER_AUTH_SECRET` to `betterAuth()` so the validated env value is used explicitly instead of relying on implicit `process.env` lookup.
- Add `console.warn` when `PLANNER_CLIENT_API_KEY` is unset in the roadmap router, so misconfiguration is visible instead of silently returning an empty list.

## Test plan

- [ ] `pnpm --filter antalmanac build` succeeds with valid `.env`
- [ ] Auth sign-in/sign-out still works locally
- [ ] Roadmap fetch logs a warning (not an error) when `PLANNER_CLIENT_API_KEY` is omitted
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d4a494a5-0ded-41e3-88e2-3bb7a0cf93e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d4a494a5-0ded-41e3-88e2-3bb7a0cf93e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

