### PR TITLE
fix(antalmanac): clear Map location flyTo timeout on unmount

### DIFF
--- a/apps/antalmanac/src/components/Map/Map.tsx
+++ b/apps/antalmanac/src/components/Map/Map.tsx
@@ -223,10 +223,14 @@ export default function CourseMap() {
             return;
         }
 
-        setTimeout(() => {
+        const timeoutId = window.setTimeout(() => {
             map.current?.flyTo([building.lat + 0.001, building.lng], 18, { duration: 250, animate: false });
             markerRef.current?.openPopup();
         }, 250);
+
+        return () => {
+            window.clearTimeout(timeoutId);
+        };
     }, [searchParams]);
 
     const handleChange = useCallback(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes a react-doctor `effect-needs-cleanup` error in the map location effect.

When `searchParams` includes a `location`, the map flies to the building and opens its popup after a short delay. Previously, that `setTimeout` was never cleared, so it could fire after unmount or after `searchParams` changed.

## Changes

- Store the timeout id and return a cleanup function that calls `clearTimeout`.

## CI note

The first run failed only on `deploy-staging` with a transient AWS/SST error (`WebsiteAssetsCors` could not read S3 bucket CORS config). `lint`, `test`, and the Next.js/OpenNext build all passed. Branch rebased onto latest `main` (includes #1896) and pushed to retrigger checks.

## Test plan

- [ ] Open the map with a `?location=` query param and navigate away before 250ms — no console errors or stale flyTo calls
- [ ] Change `location` query param quickly — only the latest building is focused
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1861f032-21fd-4faf-a00f-4b0b0953ef38"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1861f032-21fd-4faf-a00f-4b0b0953ef38"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

