### PR TITLE
refactor: hoist FuzzySearch pure helpers to module scope

### DIFF
--- a/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/QuickSearch/FuzzySearch.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/QuickSearch/FuzzySearch.tsx
@@ -57,6 +57,44 @@ interface SearchOption {
     result: SearchResult;
 }
 
+function getCacheKey(term: AATerm, query: string): string {
+    return `${term.shortName}:${query}`;
+}
+
+function filterOptions(options: SearchOption[]) {
+    return options;
+}
+
+function getOptionLabel(option: SearchOption) {
+    const object = option.result;
+    if (!object) return option.key;
+    switch (object.type) {
+        case resultType.GE_CATEGORY: {
+            const cat = option.key.split('-')[1].toLowerCase();
+            const num = parseInt(cat);
+            return `${emojiMap.GE_CATEGORY} GE ${cat.replace(num.toString(), romanArr[num - 1])} (${cat}): ${
+                object.name
+            }`;
+        }
+        case resultType.DEPARTMENT:
+            return `${emojiMap.DEPARTMENT} ${option.key}: ${object.name}`;
+        case resultType.COURSE:
+            return `${emojiMap.COURSE} ${object.metadata.department} ${object.metadata.number}: ${object.name}`;
+        case resultType.SECTION:
+            return `${emojiMap.SECTION} ${object.sectionCode} ${object.sectionType} ${object.sectionNum}: ${object.department} ${object.courseNumber}`;
+        default:
+            return '';
+    }
+}
+
+function groupBy(option: SearchOption) {
+    const isCourse = option.result.type === resultType.COURSE;
+    if (!isCourse) return groupType.UNGROUPED;
+
+    const isOffered = 'isOffered' in option.result && option.result.isOffered;
+    return isOffered ? groupType.OFFERED : groupType.NOT_OFFERED;
+}
+
 export function FuzzySearch() {
     const postHog = usePostHog();
     const [term] = useCourseSearchParam('term');
@@ -72,10 +110,6 @@ export function FuzzySearch() {
     const [currentTerm, setCurrentTerm] = useState<AATerm>(term);
 
     const requestTimestampRef = useRef<number | undefined>(undefined);
-
-    const getCacheKey = (term: AATerm, query: string): string => {
-        return `${term.shortName}:${query}`;
-    };
 
     const doSearch = (option: SearchOption) => {
         const result = option.result;
@@ -120,30 +154,6 @@ export function FuzzySearch() {
             category: analyticsEnum.classSearch,
             action: analyticsEnum.classSearch.actions.FUZZY_SEARCH,
         });
-    };
-
-    const filterOptions = (options: SearchOption[]) => options;
-
-    const getOptionLabel = (option: SearchOption) => {
-        const object = option.result;
-        if (!object) return option.key;
-        switch (object.type) {
-            case resultType.GE_CATEGORY: {
-                const cat = option.key.split('-')[1].toLowerCase();
-                const num = parseInt(cat);
-                return `${emojiMap.GE_CATEGORY} GE ${cat.replace(num.toString(), romanArr[num - 1])} (${cat}): ${
-                    object.name
-                }`;
-            }
-            case resultType.DEPARTMENT:
-                return `${emojiMap.DEPARTMENT} ${option.key}: ${object.name}`;
-            case resultType.COURSE:
-                return `${emojiMap.COURSE} ${object.metadata.department} ${object.metadata.number}: ${object.name}`;
-            case resultType.SECTION:
-                return `${emojiMap.SECTION} ${object.sectionCode} ${object.sectionType} ${object.sectionNum}: ${object.department} ${object.courseNumber}`;
-            default:
-                return '';
-        }
     };
 
     const requestIsCurrent = useCallback(
@@ -253,14 +263,6 @@ export function FuzzySearch() {
 
     const onClose = () => {
         setOpen(false);
-    };
-
-    const groupBy = (option: SearchOption) => {
-        const isCourse = option.result.type === resultType.COURSE;
-        if (!isCourse) return groupType.UNGROUPED;
-
-        const isOffered = 'isOffered' in option.result && option.result.isOffered;
-        return isOffered ? groupType.OFFERED : groupType.NOT_OFFERED;
     };
 
     const renderGroup = (params: AutocompleteRenderGroupParams) => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Addresses react-doctor `prefer-module-scope-pure-function` findings in quick search.

## Changes

Move these pure helpers out of the `FuzzySearch` component so they are not recreated on every render:

- `getCacheKey`
- `filterOptions`
- `getOptionLabel`
- `groupBy`

## Test plan

- [ ] Quick search autocomplete still renders grouped results correctly
- [ ] Selecting a result still submits the expected search params
- [ ] Cache key behavior unchanged across term switches
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1861f032-21fd-4faf-a00f-4b0b0953ef38"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1861f032-21fd-4faf-a00f-4b0b0953ef38"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

