### PR TITLE
chore: remove unused exports flagged

### DIFF
--- a/apps/antalmanac/src/backend/lib/rds/friendships.ts
+++ b/apps/antalmanac/src/backend/lib/rds/friendships.ts
@@ -51,7 +51,7 @@ export async function acceptFriendRequest(db: DatabaseOrTransaction, requesterId
 /**
  * Returns accepted friends where the given user sent the request.
  */
-export async function getFriendshipsSent(db: DatabaseOrTransaction, userId: string) {
+async function getFriendshipsSent(db: DatabaseOrTransaction, userId: string) {
     return db
         .select({ id: users.id, name: users.name, email: users.email, avatar: users.avatar })
         .from(friendships)
@@ -62,7 +62,7 @@ export async function getFriendshipsSent(db: DatabaseOrTransaction, userId: stri
 /**
  * Returns accepted friends where the given user received the request.
  */
-export async function getFriendshipsReceived(db: DatabaseOrTransaction, userId: string) {
+async function getFriendshipsReceived(db: DatabaseOrTransaction, userId: string) {
     return db
         .select({ id: users.id, name: users.name, email: users.email, avatar: users.avatar })
         .from(friendships)

--- a/apps/antalmanac/src/components/RightPane/CoursePane/SearchParams/helpers.ts
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/SearchParams/helpers.ts
@@ -45,7 +45,7 @@ export function hasAdvancedParams(formData: AdvancedSearchParams) {
     });
 }
 
-export function shouldShowSearchForm(formData: CourseSearchParams) {
+function shouldShowSearchForm(formData: CourseSearchParams) {
     const hasPrimarySearchInput =
         formData.sectionCode !== DEFAULT_FORM_DATA.sectionCode ||
         formData.courseNumber !== DEFAULT_FORM_DATA.courseNumber ||

--- a/apps/antalmanac/src/lib/helpers.ts
+++ b/apps/antalmanac/src/lib/helpers.ts
@@ -37,10 +37,3 @@ export function mergeSx(
         return acc;
     }, [] as any);
 }
-
-export const QUARTER_ORDER_IN_YEAR: Record<string, number> = {
-    Winter: 0,
-    Spring: 1,
-    Summer: 2,
-    Fall: 3,
-};

--- a/apps/antalmanac/src/lib/sectionThemes/index.ts
+++ b/apps/antalmanac/src/lib/sectionThemes/index.ts
@@ -25,11 +25,6 @@ export function getPalette(theme: SectionColorSetting | string, isDark: boolean)
     return isDark && def.dark ? def.dark : def.light;
 }
 
-/** Primary color (variant 0) of each family in a theme. */
-export function getPrimaryColors(theme: SectionColorSetting | string, isDark: boolean): string[] {
-    return getPalette(theme, isDark).map((family) => family[0]);
-}
-
 /* ------------------------------------------------------------------ *
  * Theme color assignments
  *

--- a/apps/antalmanac/src/lib/sectionThemes/themes.ts
+++ b/apps/antalmanac/src/lib/sectionThemes/themes.ts
@@ -88,6 +88,3 @@ export const SECTION_THEMES: readonly SectionTheme[] = [
     { id: 'catppuccin', name: 'Catppuccin', light: catppuccinLatte, dark: catppuccinMocha },
     { id: 'quietLuxury', name: 'Quiet Luxury', light: quietLuxuryPalette },
 ];
-
-/** The default theme — also the source of truth for colors when a user picks "custom". */
-export const DEFAULT_THEME_ID: SectionThemeId = 'default';

--- a/apps/antalmanac/src/lib/utils.ts
+++ b/apps/antalmanac/src/lib/utils.ts
@@ -37,24 +37,6 @@ export function getErrorMessage(e: unknown) {
     return e instanceof Error ? e.message : String(e);
 }
 
-export function replaceUrlSearchParams(update: (params: URLSearchParams) => void) {
-    const url = new URL(window.location.href);
-    const params = new URLSearchParams(url.search);
-    update(params);
-
-    const query = params.toString();
-    const nextUrl = `${url.pathname}${query ? `?${query}` : ''}${url.hash}`;
-    history.replaceState({ url: 'url' }, 'url', nextUrl);
-}
-
-export const safeUnreachableCase = <T>(v: never, retVal?: T): T | undefined => {
-    // if this code is running, v didn't turn out to be `never` after all, so tell TS that
-    const castedV = v as unknown;
-
-    console.error(`Reached a (safe) unreachable case: ${castedV}`);
-    return retVal;
-};
-
 /**
  * Moves an array item from one position to another, in place.
  * For an immutable alternative, see `arrayMove` from `dnd-kit`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Removes dead code and drops unnecessary `export` keywords from symbols that are only used within their own modules.

## Changes

- Delete unused helpers from `lib/utils.ts` (`replaceUrlSearchParams`, `safeUnreachableCase`)
- Delete unused `QUARTER_ORDER_IN_YEAR` from `lib/helpers.ts`
- Delete unused `getPrimaryColors` and `DEFAULT_THEME_ID` from section theme modules
- Make `getFriendshipsSent` / `getFriendshipsReceived` module-private
- Make `shouldShowSearchForm` module-private

## Test plan

- [ ] Typecheck / build passes
- [ ] No import sites broken (grep confirms these symbols were not imported elsewhere)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1861f032-21fd-4faf-a00f-4b0b0953ef38"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1861f032-21fd-4faf-a00f-4b0b0953ef38"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

