### PR TITLE
perf(aants): hoist Pacific Intl formatters to module scope

### DIFF
--- a/apps/aants/src/helpers/notificationDispatch.ts
+++ b/apps/aants/src/helpers/notificationDispatch.ts
@@ -24,6 +24,21 @@ export interface CourseDetails {
 }
 
 const BATCH_SIZE = 450;
+const PACIFIC_TIME_ZONE = 'America/Los_Angeles';
+
+const PACIFIC_TIME_FORMATTER = new Intl.DateTimeFormat('en-US', {
+    hour: 'numeric',
+    minute: '2-digit',
+    hour12: true,
+    timeZone: PACIFIC_TIME_ZONE,
+});
+
+const PACIFIC_DATE_FORMATTER = new Intl.DateTimeFormat('en-US', {
+    month: 'numeric',
+    day: 'numeric',
+    year: 'numeric',
+    timeZone: PACIFIC_TIME_ZONE,
+});
 
 /**
  * Batches an array of course codes into smaller arrays based on a predefined BATCH_SIZE.
@@ -44,23 +59,8 @@ function batchCourseCodes(codes: string[]): string[][] {
  */
 function getFormattedTime(): string {
     const now = new Date();
-    const timeZone = 'America/Los_Angeles'; // PST/PDT
 
-    return (
-        new Intl.DateTimeFormat('en-US', {
-            hour: 'numeric',
-            minute: '2-digit',
-            hour12: true,
-            timeZone,
-        }).format(now) +
-        ' on ' +
-        new Intl.DateTimeFormat('en-US', {
-            month: 'numeric',
-            day: 'numeric',
-            year: 'numeric',
-            timeZone,
-        }).format(now)
-    );
+    return `${PACIFIC_TIME_FORMATTER.format(now)} on ${PACIFIC_DATE_FORMATTER.format(now)}`;
 }
 
 /**


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Addresses react-doctor `js-hoist-intl` in the aants notification email helper.

## Changes

Hoist `Intl.DateTimeFormat` instances for Pacific time/date to module scope in `notificationDispatch.ts` so `getFormattedTime()` does not rebuild formatters on every call.

## Test plan

- [ ] Notification emails still render the same timestamp format
- [ ] `pnpm lint` passes
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1861f032-21fd-4faf-a00f-4b0b0953ef38"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1861f032-21fd-4faf-a00f-4b0b0953ef38"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

