### PR TITLE
chore(aants): remove unused exports flagged by react-doctor

### DIFF
--- a/apps/aants/src/emails/CourseNotificationEmail.tsx
+++ b/apps/aants/src/emails/CourseNotificationEmail.tsx
@@ -235,5 +235,3 @@ export function CourseNotificationEmail({
         </Html>
     );
 }
-
-export default CourseNotificationEmail;

--- a/apps/aants/src/theme.ts
+++ b/apps/aants/src/theme.ts
@@ -7,16 +7,6 @@
 export const BLUE = '#305db7';
 
 /**
- * Enrollment status text colors — matches lightTheme.enrollmentStatus in Theme.tsx.
- * Used as the semantic color anchor; pill variants below are derived from these hues.
- */
-export const ENROLLMENT_STATUS_COLORS = {
-    open: '#00c853',
-    waitlist: '#ff9800',
-    full: '#e53935',
-} as const;
-
-/**
  * Email pill styles for each enrollment status.
  * Background is a pale tint of the status hue; text is a darker shade for WCAG contrast.
  */


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Same cleanup pattern as #1896, scoped to aants.

## Changes

- Remove unused `export default` from `CourseNotificationEmail.tsx` (named export is already used)
- Delete unused `ENROLLMENT_STATUS_COLORS` from `theme.ts` (`STATUS_PILL_STYLES` is what callers use)

## Test plan

- [ ] Email preview script still works (`scripts/previewEmail.tsx`)
- [ ] `pnpm lint` passes
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1861f032-21fd-4faf-a00f-4b0b0953ef38"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1861f032-21fd-4faf-a00f-4b0b0953ef38"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

