### PR TITLE
perf: unthrottle get-search-data (#1870)

### DIFF
--- a/apps/antalmanac/scripts/get-search-data.ts
+++ b/apps/antalmanac/scripts/get-search-data.ts
@@ -15,9 +15,6 @@ const aapiClient = createClient({ apiKey: env.ANTEATER_API_KEY });
 
 const MAX_COURSES = 10_000;
 
-// Delay between GraphQL requests to avoid triggering AAPI rate limits / OOM.
-const DELAY_MS = 500;
-
 const ALIASES: Record<string, string | undefined> = {
     COMPSCI: 'CS',
     EARTHSS: 'ESS',
@@ -126,12 +123,7 @@ async function main() {
             string,
             Pick<WebsocDepartment, 'deptCode' | 'deptName'> & Pick<WebsocCourse, 'courseNumber' | 'courseTitle'>
         >();
-        for (let i = 0; i < activeTerms.length; i++) {
-            if (i > 0) {
-                await new Promise((resolve) => setTimeout(resolve, DELAY_MS));
-            }
-            const { year, quarter } = activeTerms[i];
-
+        for (const { year, quarter } of activeTerms) {
             const websocData = await aapiClient.websoc.query({ year, quarter });
             const chunk = getWebsocCoursesFromResponse(websocData);
             for (const [key, course] of chunk) {
@@ -186,12 +178,7 @@ async function main() {
     const refreshShortNames = new Set(activeTerms.map((t) => t.shortName));
     let count = 0;
 
-    /*
-     * Fetch section-code data one term at a time with a fixed delay between requests.
-     * Sequential execution (rather than staggered Promise.all) ensures we never have
-     * concurrent in-flight GraphQL calls, which matters while AAPI has OOM constraints.
-     */
-    let requestsMade = 0;
+    // Fetch section-code data one term at a time to avoid concurrent GraphQL OOMs on AAPI.
     for (const term of termData) {
         try {
             const { year, quarter } = term;
@@ -211,12 +198,6 @@ async function main() {
             } catch {
                 console.log(`${term.shortName} doesn't exist in cache, rebuilding.`);
             }
-
-            // Stagger requests to respect AAPI rate limits / avoid OOM
-            if (requestsMade > 0) {
-                await new Promise((resolve) => setTimeout(resolve, DELAY_MS));
-            }
-            requestsMade++;
 
             const query = buildSectionCodesQuery(term);
             const res = await aapiClient.graphql<SectionCodesGraphQLResponse>(query);

--- a/apps/antalmanac/scripts/get-search-data.ts
+++ b/apps/antalmanac/scripts/get-search-data.ts
@@ -15,6 +15,22 @@ const aapiClient = createClient({ apiKey: env.ANTEATER_API_KEY });
 
 const MAX_COURSES = 10_000;
 
+// Full parallelism trips AAPI's Cloudflare Worker resource limit (error 1102).
+const CONCURRENCY = 5;
+
+async function mapWithConcurrency<T, R>(items: T[], limit: number, fn: (item: T) => Promise<R>): Promise<R[]> {
+    const results: R[] = Array.from({ length: items.length });
+    let next = 0;
+    async function worker() {
+        while (next < items.length) {
+            const index = next++;
+            results[index] = await fn(items[index]);
+        }
+    }
+    await Promise.all(Array.from({ length: Math.min(limit, items.length) }, worker));
+    return results;
+}
+
 const ALIASES: Record<string, string | undefined> = {
     COMPSCI: 'CS',
     EARTHSS: 'ESS',
@@ -123,10 +139,11 @@ async function main() {
             string,
             Pick<WebsocDepartment, 'deptCode' | 'deptName'> & Pick<WebsocCourse, 'courseNumber' | 'courseTitle'>
         >();
-        for (const { year, quarter } of activeTerms) {
-            const websocData = await aapiClient.websoc.query({ year, quarter });
-            const chunk = getWebsocCoursesFromResponse(websocData);
-            for (const [key, course] of chunk) {
+        const websocResponses = await mapWithConcurrency(activeTerms, CONCURRENCY, ({ year, quarter }) =>
+            aapiClient.websoc.query({ year, quarter })
+        );
+        for (const websocData of websocResponses) {
+            for (const [key, course] of getWebsocCoursesFromResponse(websocData)) {
                 fromWebsoc.set(key, course);
             }
         }
@@ -176,28 +193,31 @@ async function main() {
     );
 
     const refreshShortNames = new Set(activeTerms.map((t) => t.shortName));
-    let count = 0;
 
-    // Fetch section-code data one term at a time to avoid concurrent GraphQL OOMs on AAPI.
+    const termsToFetch: AATerm[] = [];
     for (const term of termData) {
+        const { year, quarter } = term;
+        const fileName = join(GENERATED_TERMS_DIR, `${quarter}_${year}.json`);
+
+        try {
+            await access(fileName);
+
+            if (!refreshShortNames.has(term.shortName)) {
+                console.log(`Skipping ${term.shortName}, cache exists and term is outside enrollment refresh window.`);
+                continue;
+            }
+            console.log(`Updating section-code cache for active term (${term.shortName})...`);
+        } catch {
+            console.log(`${term.shortName} doesn't exist in cache, rebuilding.`);
+        }
+
+        termsToFetch.push(term);
+    }
+
+    const counts = await mapWithConcurrency(termsToFetch, CONCURRENCY, async (term) => {
         try {
             const { year, quarter } = term;
-            const parsedTerm = `${quarter}_${year}`;
-            const fileName = join(GENERATED_TERMS_DIR, `${parsedTerm}.json`);
-
-            try {
-                await access(fileName);
-
-                if (!refreshShortNames.has(term.shortName)) {
-                    console.log(
-                        `Skipping ${term.shortName}, cache exists and term is outside enrollment refresh window.`
-                    );
-                    continue;
-                }
-                console.log(`Updating section-code cache for active term (${term.shortName})...`);
-            } catch {
-                console.log(`${term.shortName} doesn't exist in cache, rebuilding.`);
-            }
+            const fileName = join(GENERATED_TERMS_DIR, `${quarter}_${year}.json`);
 
             const query = buildSectionCodesQuery(term);
             const res = await aapiClient.graphql<SectionCodesGraphQLResponse>(query);
@@ -211,12 +231,14 @@ async function main() {
             console.log(`Fetched ${numKeys} section codes for ${term.shortName} from Anteater API.`);
 
             await writeFile(fileName, JSON.stringify(parsedSectionData, null, 2));
-            count += numKeys;
+            return numKeys;
         } catch (error) {
             console.error(`ERROR for term "${term.shortName}":`);
             throw error;
         }
-    }
+    });
+
+    const count = counts.reduce((total, numKeys) => total + numKeys, 0);
 
     console.log(`Fetched ${count} section codes for ${termData.length} terms from Anteater API.`);
     console.log('Cache generated.');

--- a/apps/antalmanac/scripts/get-search-data.ts
+++ b/apps/antalmanac/scripts/get-search-data.ts
@@ -16,20 +16,7 @@ const aapiClient = createClient({ apiKey: env.ANTEATER_API_KEY });
 const MAX_COURSES = 10_000;
 
 // Full parallelism trips AAPI's Cloudflare Worker resource limit (error 1102).
-const CONCURRENCY = 10;
-
-async function mapWithConcurrency<T, R>(items: T[], limit: number, fn: (item: T) => Promise<R>): Promise<R[]> {
-    const results: R[] = Array.from({ length: items.length });
-    let next = 0;
-    async function worker() {
-        while (next < items.length) {
-            const index = next++;
-            results[index] = await fn(items[index]);
-        }
-    }
-    await Promise.all(Array.from({ length: Math.min(limit, items.length) }, worker));
-    return results;
-}
+const BATCH_SIZE = 10;
 
 const ALIASES: Record<string, string | undefined> = {
     COMPSCI: 'CS',
@@ -139,8 +126,8 @@ async function main() {
             string,
             Pick<WebsocDepartment, 'deptCode' | 'deptName'> & Pick<WebsocCourse, 'courseNumber' | 'courseTitle'>
         >();
-        const websocResponses = await mapWithConcurrency(activeTerms, CONCURRENCY, ({ year, quarter }) =>
-            aapiClient.websoc.query({ year, quarter })
+        const websocResponses = await Promise.all(
+            activeTerms.map(({ year, quarter }) => aapiClient.websoc.query({ year, quarter }))
         );
         for (const websocData of websocResponses) {
             for (const [key, course] of getWebsocCoursesFromResponse(websocData)) {
@@ -214,31 +201,29 @@ async function main() {
         termsToFetch.push(term);
     }
 
-    const counts = await mapWithConcurrency(termsToFetch, CONCURRENCY, async (term) => {
-        try {
-            const { year, quarter } = term;
-            const fileName = join(GENERATED_TERMS_DIR, `${quarter}_${year}.json`);
+    let count = 0;
+    for (let i = 0; i < termsToFetch.length; i += BATCH_SIZE) {
+        const counts = await Promise.all(
+            termsToFetch.slice(i, i + BATCH_SIZE).map(async (term) => {
+                const { year, quarter } = term;
+                const fileName = join(GENERATED_TERMS_DIR, `${quarter}_${year}.json`);
 
-            const query = buildSectionCodesQuery(term);
-            const res = await aapiClient.graphql<SectionCodesGraphQLResponse>(query);
-            if (!res) {
-                throw new Error(`Error fetching section codes for ${term.shortName}.`);
-            }
+                const res = await aapiClient.graphql<SectionCodesGraphQLResponse>(buildSectionCodesQuery(term));
+                if (!res) {
+                    throw new Error(`Error fetching section codes for ${term.shortName}.`);
+                }
 
-            const parsedSectionData = parseSectionCodes(res);
-            const numKeys = Object.keys(parsedSectionData).length;
+                const parsedSectionData = parseSectionCodes(res);
+                const numKeys = Object.keys(parsedSectionData).length;
 
-            console.log(`Fetched ${numKeys} section codes for ${term.shortName} from Anteater API.`);
+                console.log(`Fetched ${numKeys} section codes for ${term.shortName} from Anteater API.`);
 
-            await writeFile(fileName, JSON.stringify(parsedSectionData, null, 2));
-            return numKeys;
-        } catch (error) {
-            console.error(`ERROR for term "${term.shortName}":`);
-            throw error;
-        }
-    });
-
-    const count = counts.reduce((total, numKeys) => total + numKeys, 0);
+                await writeFile(fileName, JSON.stringify(parsedSectionData, null, 2));
+                return numKeys;
+            })
+        );
+        count += counts.reduce((total, numKeys) => total + numKeys, 0);
+    }
 
     console.log(`Fetched ${count} section codes for ${termData.length} terms from Anteater API.`);
     console.log('Cache generated.');

--- a/apps/antalmanac/scripts/get-search-data.ts
+++ b/apps/antalmanac/scripts/get-search-data.ts
@@ -16,7 +16,7 @@ const aapiClient = createClient({ apiKey: env.ANTEATER_API_KEY });
 const MAX_COURSES = 10_000;
 
 // Full parallelism trips AAPI's Cloudflare Worker resource limit (error 1102).
-const CONCURRENCY = 5;
+const CONCURRENCY = 10;
 
 async function mapWithConcurrency<T, R>(items: T[], limit: number, fn: (item: T) => Promise<R>): Promise<R[]> {
     const results: R[] = Array.from({ length: items.length });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Unthrottles `get-search-data` by removing the artificial 500ms inter-request delays from #1764 and fetching WebSOC + section-code data in parallel with **bounded concurrency (5 in-flight)**.

Full parallelism trips AAPI's Cloudflare Worker resource limit (error 1102); capping concurrency keeps cold rebuilds fast without overwhelming the API.

## Test Plan

- [ ] CI passes
- [ ] `pnpm --filter antalmanac get-data` completes without AAPI 1102 errors

## Issues

Closes #1870
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e29dd736-1830-45f5-834d-43e200dc4081"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e29dd736-1830-45f5-834d-43e200dc4081"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

