### PR TITLE
perf: html2canvas on demand for schedule screenshots

### DIFF
--- a/apps/antalmanac/src/components/buttons/Screenshot.tsx
+++ b/apps/antalmanac/src/components/buttons/Screenshot.tsx
@@ -3,7 +3,6 @@ import { useThemeStore } from '$stores/SettingsStore';
 import { Panorama } from '@mui/icons-material';
 import { IconButton, Tooltip } from '@mui/material';
 import { saveAs } from 'file-saver';
-import html2canvas from 'html2canvas';
 import { usePostHog } from 'posthog-js/react';
 
 interface ScreenshotButtonProps {
@@ -23,13 +22,20 @@ const ScreenshotButton = ({ onScreenshot }: ScreenshotButtonProps) => {
         onScreenshot?.();
 
         setTimeout(() => {
-            void html2canvas(document.getElementById('screenshot') as HTMLElement, {
-                scale: 2.5,
-                backgroundColor: isDark ? '#303030' : '#fafafa',
-            }).then((canvas) => {
+            void (async () => {
+                const element = document.getElementById('screenshot');
+                if (!element) {
+                    return;
+                }
+
+                const { default: html2canvas } = await import('html2canvas');
+                const canvas = await html2canvas(element, {
+                    scale: 2.5,
+                    backgroundColor: isDark ? '#303030' : '#fafafa',
+                });
                 const imgRaw = canvas.toDataURL('image/png');
                 saveAs(imgRaw, 'Schedule.png');
-            });
+            })();
         }, 1);
     };
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Dynamically imports `html2canvas` when the user clicks the schedule screenshot button instead of bundling it in the initial client load.

## Why

`html2canvas` is only used for an optional calendar action, but it was statically imported through `Screenshot.tsx` → `CalendarToolbar`, pulling it into the main bundle. Lighthouse flagged ~350 KiB of unused JavaScript on initial load.

## Changes

- Remove the top-level `html2canvas` import from `Screenshot.tsx`
- `await import('html2canvas')` inside the existing click handler (after the 1ms DOM settle timeout)
- Guard against a missing `#screenshot` element before capture

## Test plan

- [ ] Open the calendar on desktop
- [ ] Click the screenshot button in the toolbar
- [ ] Confirm a `Schedule.png` download still works in light and dark mode
- [ ] Verify no console errors on click

## Expected impact

- Smaller initial JS bundle
- No user-visible behavior change (first screenshot click may have a brief extra delay while the chunk loads)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e72bb3e5-1112-4189-a33f-ad357032c7b3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e72bb3e5-1112-4189-a33f-ad357032c7b3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

