### PR TITLE
chore: remove unused fields from AppStore

### DIFF
--- a/apps/antalmanac/src/stores/AppStore.ts
+++ b/apps/antalmanac/src/stores/AppStore.ts
@@ -17,7 +17,6 @@ import actionTypesStore, {
     type AddScheduleAction,
     type ReorderAddedCoursesAction,
 } from '$actions/ActionTypesStore';
-import type { CalendarEvent, CourseEvent } from '$components/Calendar/types';
 import { courseColorKey } from '$lib/sectionThemes';
 import { useFallbackStore } from '$stores/FallbackStore';
 import { useHiddenCoursesStore } from '$stores/HiddenCoursesStore';
@@ -39,10 +38,6 @@ class AppStore extends EventEmitter {
 
     colorPickers: Record<string, EventEmitter>;
 
-    eventsInCalendar: CalendarEvent[];
-
-    finalsEventsInCalendar: CourseEvent[];
-
     unsavedChanges: boolean;
 
     constructor() {
@@ -51,8 +46,6 @@ class AppStore extends EventEmitter {
         this.customEvents = [];
         this.schedule = new Schedules();
         this.colorPickers = {};
-        this.eventsInCalendar = [];
-        this.finalsEventsInCalendar = [];
         this.unsavedChanges = false;
 
         if (typeof window !== 'undefined') {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Removes dead instance fields from `AppStore`:

- `eventsInCalendar`
- `finalsEventsInCalendar`

These were initialized in the constructor but never read or written. Calendar data is already accessed through the existing getters (`getEventsInCalendar()`, `getFinalEventsInCalendar()`, etc.) which delegate to `Schedules`.

Also removes the now-unused `CalendarEvent` / `CourseEvent` type import.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-09a41586-2704-4790-8d24-c2665cbb27fc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-09a41586-2704-4790-8d24-c2665cbb27fc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

