### PR TITLE
Replace color picker registration with derived display color hook

### DIFF
--- a/apps/antalmanac/src/components/ColorPicker.tsx
+++ b/apps/antalmanac/src/components/ColorPicker.tsx
@@ -1,15 +1,14 @@
 import { changeCourseColor, changeCustomEventColor } from '$actions/AppStoreActions';
+import { useSectionDisplayColor } from '$hooks/useSectionDisplayColor';
 import { AnalyticsCategory, logAnalytics } from '$lib/analytics/analytics';
-import { courseColorKey, customEventColorKey, getPalette, resolveAssignment } from '$lib/sectionThemes';
-import AppStore from '$stores/AppStore';
+import { courseColorKey, customEventColorKey } from '$lib/sectionThemes';
 import { colorPickerPresetColors } from '$stores/scheduleHelpers';
-import { selectActiveSectionColor, useSectionThemeStore } from '$stores/SectionThemeStore';
-import { useThemeStore } from '$stores/SettingsStore';
+import { useSectionThemeStore } from '$stores/SectionThemeStore';
 import { ColorLens } from '@mui/icons-material';
 import { IconButton, Popover, PopoverProps, Tooltip } from '@mui/material';
 import { CustomEventId, type AATerm } from '@packages/antalmanac-types';
 import { PostHog, usePostHog } from 'posthog-js/react';
-import { memo, useCallback, useEffect, useMemo, useState } from 'react';
+import { memo, useCallback, useEffect, useState } from 'react';
 import { SketchPicker } from 'react-color';
 
 interface ColorPickerProps {
@@ -34,53 +33,27 @@ const ColorPicker = memo(function ColorPicker({
     sectionCode,
 }: ColorPickerProps) {
     const [anchorEl, setAnchorEl] = useState<PopoverProps['anchorEl']>(null);
-    const [currColor, setCurrColor] = useState(color);
+    const [draftColor, setDraftColor] = useState<string | null>(null);
 
     const sectionColor = useSectionThemeStore((s) => s.sectionColor);
-    const activeSectionColor = useSectionThemeStore(selectActiveSectionColor);
-    const activeAssignments = useSectionThemeStore((s) => s.activeAssignments);
     const setManualColor = useSectionThemeStore((s) => s.setManualColor);
-    const isDark = useThemeStore((s) => s.isDark);
 
     const postHog = usePostHog();
 
-    // When a preset theme is active (including while previewing one on hover), show the theme's
-    // resolved color for this section/custom event instead of the stored color, so the swatch and
-    // picker track the theme. Falls back to the live/stored color on the custom setting.
-    const themedColor = useMemo(() => {
-        if (activeSectionColor === 'custom') return null;
-        const key =
-            isCustomEvent && customEventID != null
-                ? customEventColorKey(customEventID)
-                : sectionCode != null && term != null
-                  ? courseColorKey(term, sectionCode)
-                  : null;
-        const value = key != null ? activeAssignments[key] : undefined;
-        return value != null ? resolveAssignment(value, getPalette(activeSectionColor, isDark)) : null;
-    }, [activeSectionColor, activeAssignments, isDark, isCustomEvent, customEventID, sectionCode, term]);
+    const displayColor = useSectionDisplayColor({
+        term,
+        sectionCode,
+        customEventID: isCustomEvent ? customEventID : undefined,
+        fallbackColor: color,
+    });
 
-    const displayColor = themedColor ?? currColor;
-
-    // Reflect color changes that come from the parent (e.g. theme switch repaints).
-    useEffect(() => {
-        setCurrColor(color);
-    }, [color]);
-
-    const updateColor = useCallback((newColor: string) => {
-        setCurrColor((prev) => (prev === newColor ? prev : newColor));
-    }, []);
+    const swatchColor = draftColor ?? displayColor;
 
     useEffect(() => {
-        let colorPickerId;
-        if (isCustomEvent && customEventID) colorPickerId = customEventID.toString();
-        else if (sectionCode && term) colorPickerId = courseColorKey(term, sectionCode);
-        else throw new Error("Colorpicker custom component wasn't supplied a custom event id or a section code.");
-        AppStore.registerColorPicker(colorPickerId, updateColor);
-
-        return () => {
-            AppStore.unregisterColorPicker(colorPickerId, updateColor);
-        };
-    }, [isCustomEvent, customEventID, sectionCode, term, updateColor]);
+        if (!anchorEl) {
+            setDraftColor(null);
+        }
+    }, [anchorEl]);
 
     const openPicker = (target: HTMLElement, postHog?: PostHog) => {
         setAnchorEl(target);
@@ -100,32 +73,35 @@ const ColorPicker = memo(function ColorPicker({
         setAnchorEl(null);
     };
 
-    const handleColorChange = (newColor: { hex: string }) => {
-        setCurrColor(newColor.hex);
+    const handleColorChange = useCallback(
+        (newColor: { hex: string }) => {
+            setDraftColor(newColor.hex);
 
-        // On a preset theme, store the change as a per-section override layered on the
-        // theme (keeps the theme selected and leaves the user's custom palette untouched).
-        if (sectionColor !== 'custom') {
-            const key =
-                isCustomEvent && customEventID
-                    ? customEventColorKey(customEventID)
-                    : sectionCode != null && term != null
-                      ? courseColorKey(term, sectionCode)
-                      : null;
-            if (key != null) setManualColor(sectionColor, key, newColor.hex);
-            return;
-        }
+            // On a preset theme, store the change as a per-section override layered on the
+            // theme (keeps the theme selected and leaves the user's custom palette untouched).
+            if (sectionColor !== 'custom') {
+                const key =
+                    isCustomEvent && customEventID
+                        ? customEventColorKey(customEventID)
+                        : sectionCode != null && term != null
+                          ? courseColorKey(term, sectionCode)
+                          : null;
+                if (key != null) setManualColor(sectionColor, key, newColor.hex);
+                return;
+            }
 
-        // On custom, edit the course/event's stored color directly.
-        if (isCustomEvent && customEventID) changeCustomEventColor(customEventID, newColor.hex);
-        else if (sectionCode && term) changeCourseColor(sectionCode, term, newColor.hex);
-    };
+            // On custom, edit the course/event's stored color directly.
+            if (isCustomEvent && customEventID) changeCustomEventColor(customEventID, newColor.hex);
+            else if (sectionCode && term) changeCourseColor(sectionCode, term, newColor.hex);
+        },
+        [sectionColor, isCustomEvent, customEventID, sectionCode, term, setManualColor]
+    );
 
     return (
         <>
             <Tooltip title="Change Color">
                 <IconButton
-                    sx={{ color: displayColor, padding: 0.5 }}
+                    sx={{ color: swatchColor, padding: 0.5 }}
                     onClick={(e) => {
                         handleClick(e, postHog);
                     }}
@@ -148,11 +124,7 @@ const ColorPicker = memo(function ColorPicker({
                     horizontal: 'left',
                 }}
             >
-                <SketchPicker
-                    color={displayColor}
-                    onChange={handleColorChange}
-                    presetColors={colorPickerPresetColors}
-                />
+                <SketchPicker color={swatchColor} onChange={handleColorChange} presetColors={colorPickerPresetColors} />
             </Popover>
         </>
     );

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody/SectionTableBodyRowColorStrip.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody/SectionTableBodyRowColorStrip.tsx
@@ -1,26 +1,16 @@
 import { changeCourseColor } from '$actions/AppStoreActions';
 import { useIsMobile } from '$hooks/useIsMobile';
-import {
-    courseColorKey,
-    getPalette,
-    resolveAssignment,
-    type SectionColorSetting,
-    type ThemeAssignmentMap,
-} from '$lib/sectionThemes';
-import AppStore from '$stores/AppStore';
+import { useSectionDisplayColor } from '$hooks/useSectionDisplayColor';
+import { courseColorKey } from '$lib/sectionThemes';
 import { colorPickerPresetColors } from '$stores/scheduleHelpers';
-import { selectActiveSectionColor, useSectionThemeStore } from '$stores/SectionThemeStore';
-import { useThemeStore } from '$stores/SettingsStore';
+import { useSectionThemeStore } from '$stores/SectionThemeStore';
 import { Box, Popover, PopoverProps, SxProps, TableCell, Tooltip } from '@mui/material';
 import { AASection, AATerm } from '@packages/antalmanac-types';
-import { memo, useCallback, useEffect, useMemo, useState } from 'react';
+import { memo, useCallback, useEffect, useState } from 'react';
 import { SketchPicker } from 'react-color';
 
 const STRIP_SHRINK_PX = 5;
 const STRIP_EXPAND_PX = 8;
-
-/** Stable empty map so the color-sync effect doesn't re-run (and re-subscribe) every render. */
-const EMPTY_ASSIGNMENTS: ThemeAssignmentMap = {};
 
 const cellSx: SxProps = {
     position: 'relative',
@@ -29,24 +19,6 @@ const cellSx: SxProps = {
     verticalAlign: 'stretch',
     overflow: 'visible',
 };
-
-function getDisplayColor(
-    section: AASection,
-    term: AATerm,
-    setting: SectionColorSetting,
-    assignments: ThemeAssignmentMap,
-    palette: readonly (readonly string[])[]
-): string {
-    const course = AppStore.schedule.getExistingCourseInSchedule(section.sectionCode, term);
-    if (!course) {
-        return section.color ?? '#5ec8e0';
-    }
-    if (setting === 'custom') {
-        return course.section.color;
-    }
-    const value = assignments[courseColorKey(term, section.sectionCode)];
-    return value != null ? resolveAssignment(value, palette) : course.section.color;
-}
 
 interface SectionTableBodyRowColorStripProps {
     section: AASection;
@@ -59,27 +31,26 @@ export const SectionTableBodyRowColorStrip = memo(({ section, term, visible }: S
     const clickable = !isMobile && visible;
 
     const sectionColor = useSectionThemeStore((s) => s.sectionColor);
-    const activeSectionColor = useSectionThemeStore(selectActiveSectionColor);
     const setManualColor = useSectionThemeStore((s) => s.setManualColor);
-    // Read the single resolved source of truth so the strip always matches the calendar
-    // (which reads the same map via useSectionThemeAssignments).
-    const activeAssignments = useSectionThemeStore((s) => s.activeAssignments);
-    const isDark = useThemeStore((s) => s.isDark);
-
-    const palette = useMemo(() => getPalette(activeSectionColor, isDark), [activeSectionColor, isDark]);
-    const assignments = activeSectionColor === 'custom' ? EMPTY_ASSIGNMENTS : activeAssignments;
 
     const [hovered, setHovered] = useState(false);
-    const [currColor, setCurrColor] = useState(() =>
-        getDisplayColor(section, term, activeSectionColor, assignments, palette)
-    );
+    const [draftColor, setDraftColor] = useState<string | null>(null);
     const [anchorEl, setAnchorEl] = useState<PopoverProps['anchorEl']>(null);
 
+    const displayColor = useSectionDisplayColor({
+        term,
+        sectionCode: section.sectionCode,
+        fallbackColor: section.color ?? '#5ec8e0',
+    });
+
+    const swatchColor = draftColor ?? displayColor;
     const stripWidth = visible && clickable && hovered ? STRIP_EXPAND_PX : STRIP_SHRINK_PX;
 
-    const updateColorFromPicker = useCallback((newColor: string) => {
-        setCurrColor(newColor);
-    }, []);
+    useEffect(() => {
+        if (!anchorEl) {
+            setDraftColor(null);
+        }
+    }, [anchorEl]);
 
     const handleOpenPicker = useCallback((anchorEl: HTMLElement) => {
         setAnchorEl((prev) => (prev === anchorEl ? null : anchorEl));
@@ -91,7 +62,7 @@ export const SectionTableBodyRowColorStrip = memo(({ section, term, visible }: S
 
     const handleColorChange = useCallback(
         (newColor: { hex: string }) => {
-            setCurrColor(newColor.hex);
+            setDraftColor(newColor.hex);
             // On a preset theme, store an override layered on the theme; on custom, edit
             // the section's stored color directly.
             if (sectionColor !== 'custom') {
@@ -102,35 +73,6 @@ export const SectionTableBodyRowColorStrip = memo(({ section, term, visible }: S
         },
         [section.sectionCode, term, sectionColor, setManualColor]
     );
-
-    useEffect(() => {
-        const syncColor = () => {
-            setCurrColor(getDisplayColor(section, term, activeSectionColor, assignments, palette));
-        };
-
-        syncColor();
-
-        AppStore.on('addedCoursesChange', syncColor);
-        AppStore.on('currentScheduleIndexChange', syncColor);
-        AppStore.on('colorChange', syncColor);
-
-        return () => {
-            AppStore.removeListener('addedCoursesChange', syncColor);
-            AppStore.removeListener('currentScheduleIndexChange', syncColor);
-            AppStore.removeListener('colorChange', syncColor);
-        };
-    }, [section, term, activeSectionColor, assignments, palette]);
-
-    useEffect(() => {
-        if (!visible) {
-            return;
-        }
-        const pickerId = courseColorKey(term, section.sectionCode);
-        AppStore.registerColorPicker(pickerId, updateColorFromPicker);
-        return () => {
-            AppStore.unregisterColorPicker(pickerId, updateColorFromPicker);
-        };
-    }, [visible, section.sectionCode, term, updateColorFromPicker]);
 
     if (!visible) {
         return <TableCell sx={cellSx} />;
@@ -158,7 +100,7 @@ export const SectionTableBodyRowColorStrip = memo(({ section, term, visible }: S
                                 bottom: 0,
                                 width: stripWidth,
                                 transition: 'width 120ms ease-out',
-                                bgcolor: currColor,
+                                bgcolor: swatchColor,
                                 border: 'none',
                                 p: 0,
                                 cursor: 'pointer',
@@ -175,7 +117,7 @@ export const SectionTableBodyRowColorStrip = memo(({ section, term, visible }: S
                             top: 0,
                             bottom: 0,
                             width: STRIP_SHRINK_PX,
-                            bgcolor: currColor,
+                            bgcolor: swatchColor,
                         }}
                     />
                 )}
@@ -196,7 +138,7 @@ export const SectionTableBodyRowColorStrip = memo(({ section, term, visible }: S
                     }}
                 >
                     <SketchPicker
-                        color={currColor}
+                        color={swatchColor}
                         onChange={handleColorChange}
                         presetColors={colorPickerPresetColors}
                     />

--- a/apps/antalmanac/src/hooks/useSectionDisplayColor.ts
+++ b/apps/antalmanac/src/hooks/useSectionDisplayColor.ts
@@ -1,0 +1,111 @@
+import {
+    courseColorKey,
+    customEventColorKey,
+    getPalette,
+    resolveAssignment,
+    type SectionColorSetting,
+    type ThemeAssignmentMap,
+} from '$lib/sectionThemes';
+import AppStore from '$stores/AppStore';
+import { selectActiveSectionColor, useSectionThemeStore } from '$stores/SectionThemeStore';
+import { useThemeStore } from '$stores/SettingsStore';
+import type { AATerm, CustomEventId } from '@packages/antalmanac-types';
+import { useEffect, useMemo, useState } from 'react';
+
+const EMPTY_ASSIGNMENTS: ThemeAssignmentMap = {};
+
+export interface SectionDisplayColorParams {
+    term?: AATerm;
+    sectionCode?: string;
+    customEventID?: CustomEventId;
+    fallbackColor: string;
+}
+
+export function resolveSectionDisplayColor({
+    term,
+    sectionCode,
+    customEventID,
+    fallbackColor,
+    setting,
+    assignments,
+    palette,
+}: SectionDisplayColorParams & {
+    setting: SectionColorSetting;
+    assignments: ThemeAssignmentMap;
+    palette: readonly (readonly string[])[];
+}): string {
+    if (customEventID != null) {
+        if (setting !== 'custom') {
+            const value = assignments[customEventColorKey(customEventID)];
+            if (value != null) {
+                return resolveAssignment(value, palette);
+            }
+        }
+        return AppStore.schedule.getExistingCustomEvent(customEventID)?.color ?? fallbackColor;
+    }
+
+    if (sectionCode != null && term != null) {
+        const course = AppStore.schedule.getExistingCourseInSchedule(sectionCode, term);
+        if (!course) {
+            return fallbackColor;
+        }
+        if (setting === 'custom') {
+            return course.section.color;
+        }
+        const value = assignments[courseColorKey(term, sectionCode)];
+        return value != null ? resolveAssignment(value, palette) : course.section.color;
+    }
+
+    return fallbackColor;
+}
+
+/** Bump when schedule data or colors change so consumers re-read AppStore. */
+function useSectionColorRevision(): number {
+    const [revision, setRevision] = useState(0);
+
+    useEffect(() => {
+        const bump = () => setRevision((value) => value + 1);
+
+        AppStore.on('addedCoursesChange', bump);
+        AppStore.on('customEventsChange', bump);
+        AppStore.on('currentScheduleIndexChange', bump);
+        AppStore.on('colorChange', bump);
+
+        return () => {
+            AppStore.removeListener('addedCoursesChange', bump);
+            AppStore.removeListener('customEventsChange', bump);
+            AppStore.removeListener('currentScheduleIndexChange', bump);
+            AppStore.removeListener('colorChange', bump);
+        };
+    }, []);
+
+    return revision;
+}
+
+/**
+ * Resolved swatch color for a course section or custom event.
+ * Reads the same sources as the calendar and section-table strips, so every
+ * color UI stays in sync without per-component AppStore registration.
+ */
+export function useSectionDisplayColor(params: SectionDisplayColorParams): string {
+    const activeSectionColor = useSectionThemeStore(selectActiveSectionColor);
+    const activeAssignments = useSectionThemeStore((s) => s.activeAssignments);
+    const isDark = useThemeStore((s) => s.isDark);
+    const revision = useSectionColorRevision();
+
+    const { term, sectionCode, customEventID, fallbackColor } = params;
+
+    return useMemo(
+        () =>
+            resolveSectionDisplayColor({
+                term,
+                sectionCode,
+                customEventID,
+                fallbackColor,
+                setting: activeSectionColor,
+                assignments: activeSectionColor === 'custom' ? EMPTY_ASSIGNMENTS : activeAssignments,
+                palette: getPalette(activeSectionColor, isDark),
+            }),
+        [term, sectionCode, customEventID, fallbackColor, activeSectionColor, activeAssignments, isDark, revision]
+    );
+}

--- a/apps/antalmanac/src/stores/AppStore.ts
+++ b/apps/antalmanac/src/stores/AppStore.ts
@@ -18,7 +18,6 @@ import actionTypesStore, {
     type ReorderAddedCoursesAction,
 } from '$actions/ActionTypesStore';
 import type { CalendarEvent, CourseEvent } from '$components/Calendar/types';
-import { courseColorKey } from '$lib/sectionThemes';
 import { useFallbackStore } from '$stores/FallbackStore';
 import { useHiddenCoursesStore } from '$stores/HiddenCoursesStore';
 import { deleteTempSaveData, loadTempSaveData, setTempSaveData } from '$stores/localTempSaveDataHelpers';
@@ -37,8 +36,6 @@ class AppStore extends EventEmitter {
 
     customEvents: RepeatingCustomEvent[];
 
-    colorPickers: Record<string, EventEmitter>;
-
     eventsInCalendar: CalendarEvent[];
 
     finalsEventsInCalendar: CourseEvent[];
@@ -50,7 +47,6 @@ class AppStore extends EventEmitter {
         this.setMaxListeners(300);
         this.customEvents = [];
         this.schedule = new Schedules();
-        this.colorPickers = {};
         this.eventsInCalendar = [];
         this.finalsEventsInCalendar = [];
         this.unsavedChanges = false;
@@ -145,24 +141,6 @@ class AppStore extends EventEmitter {
 
     hasUnsavedChanges() {
         return this.unsavedChanges;
-    }
-
-    registerColorPicker(id: string, update: (color: string) => void) {
-        if (id in this.colorPickers) {
-            this.colorPickers[id].on('colorChange', update);
-        } else {
-            this.colorPickers[id] = new EventEmitter();
-            this.colorPickers[id].on('colorChange', update);
-        }
-    }
-
-    unregisterColorPicker(id: string, update: (color: string) => void) {
-        if (id in this.colorPickers) {
-            this.colorPickers[id].removeListener('colorChange', update);
-            if (this.colorPickers[id].listenerCount('colorChange') === 0) {
-                delete this.colorPickers[id];
-            }
-        }
     }
 
     deleteCourse(sectionCode: string, term: AATerm, scheduleIndex: number, triggerUnsavedWarning = true) {
@@ -271,7 +249,6 @@ class AppStore extends EventEmitter {
             newColor: newColor,
         };
         actionTypesStore.autoSaveSchedule(action);
-        this.colorPickers[customEventId].emit('colorChange', newColor);
         this.emit('colorChange', false);
     }
 
@@ -447,7 +424,6 @@ class AppStore extends EventEmitter {
             newColor: newColor,
         };
         actionTypesStore.autoSaveSchedule(action);
-        this.colorPickers[courseColorKey(term, sectionCode)]?.emit('colorChange', newColor);
         this.emit('colorChange', false);
     }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Removes the per-picker `EventEmitter` registration pattern from `AppStore` (`registerColorPicker` / `unregisterColorPicker` / `colorPickers`).

Color swatches now use a shared `useSectionDisplayColor` hook that reads from the same sources as the calendar and section table:
- `SectionThemeStore.activeAssignments` for preset themes
- `AppStore.schedule` for custom per-section colors
- `AppStore` `colorChange` and related events to re-render when colors change elsewhere

Local state is only kept as a short-lived draft while the SketchPicker popover is open.

## Test Plan

- [x] `pnpm lint` passes
- [x] Unit tests that do not require generated term data pass (`34` tests)
- [ ] Manually change a section color from the table strip and confirm the calendar event detail swatch updates
- [ ] Manually change a section color from the calendar detail picker and confirm the table strip updates
- [ ] Switch section color themes and confirm swatches track theme assignments
- [ ] Undo/redo a color change and confirm swatches update

## Issues

Closes #
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d7b4afa9-8cfc-4a62-8d2b-2fcc9e8070f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d7b4afa9-8cfc-4a62-8d2b-2fcc9e8070f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

