### PR TITLE
refactor: move imported-user success state to SessionStore

### DIFF
--- a/apps/antalmanac/src/components/AuthInitializer.tsx
+++ b/apps/antalmanac/src/components/AuthInitializer.tsx
@@ -8,9 +8,7 @@ import {
     getLocalStorageUserId,
     getWasLoggedIn,
     removeLocalStorageDataCache,
-    removeLocalStorageImportedUser,
     removeLocalStorageUserId,
-    setLocalStorageImportedUser,
     setWasLoggedIn,
 } from '$lib/localStorage';
 import { setSsoCookie } from '$lib/ssoCookie';

--- a/apps/antalmanac/src/components/Header/Header.tsx
+++ b/apps/antalmanac/src/components/Header/Header.tsx
@@ -5,26 +5,26 @@ import { Save } from '$components/Header/Save';
 import { Signin } from '$components/Header/Signin';
 import { Signout } from '$components/Header/Signout';
 import { useIsMobile } from '$hooks/useIsMobile';
-import { getLocalStorageImportedUser, removeLocalStorageImportedUser } from '$lib/localStorage';
 import { BLUE } from '$src/globals';
 import { useSessionStore } from '$stores/SessionStore';
 import { AppBar, Box, Stack } from '@mui/material';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
+import { useShallow } from 'zustand/react/shallow';
 
 export function Header() {
-    const [openSuccessfulSaved, setOpenSuccessfulSaved] = useState(false);
     const [openSignoutDialog, setOpenSignoutDialog] = useState(false);
-    const importedUser = getLocalStorageImportedUser() ?? '';
-    const sessionIsValid = useSessionStore((store) => store.sessionIsValid);
+    const { sessionIsValid, importedUsername, clearImportedUsername } = useSessionStore(
+        useShallow((store) => ({
+            sessionIsValid: store.sessionIsValid,
+            importedUsername: store.importedUsername,
+            clearImportedUsername: store.clearImportedUsername,
+        }))
+    );
     const isMobile = useIsMobile();
-
-    const clearStorage = () => {
-        removeLocalStorageImportedUser();
-    };
+    const openSuccessfulSaved = importedUsername !== null && sessionIsValid;
 
     const handleCloseSuccessfulSaved = () => {
-        setOpenSuccessfulSaved(false);
-        clearStorage();
+        clearImportedUsername();
     };
 
     const handleLogoutComplete = () => {
@@ -35,12 +35,6 @@ export function Header() {
         setOpenSignoutDialog(false);
         window.location.reload();
     };
-
-    useEffect(() => {
-        if (importedUser !== '' && sessionIsValid) {
-            setOpenSuccessfulSaved(true);
-        }
-    }, [importedUser, sessionIsValid]);
 
     return (
         <Box
@@ -83,7 +77,7 @@ export function Header() {
 
                     <AlertDialog
                         open={openSuccessfulSaved}
-                        title={`Schedule from "${importedUser}" has been saved to your account!`}
+                        title={`Schedule from "${importedUsername}" has been saved to your account!`}
                         severity="success"
                         onClose={handleCloseSuccessfulSaved}
                     >

--- a/apps/antalmanac/src/lib/localStorage.ts
+++ b/apps/antalmanac/src/lib/localStorage.ts
@@ -35,18 +35,6 @@ enum LocalStorageKeys {
 
 const LSK = LocalStorageKeys;
 
-export function setLocalStorageImportedUser(value: string) {
-    window.localStorage.setItem(LSK.importedUser, value);
-}
-
-export function getLocalStorageImportedUser() {
-    return window.localStorage.getItem(LSK.importedUser);
-}
-
-export function removeLocalStorageImportedUser() {
-    window.localStorage.removeItem(LSK.importedUser);
-}
-
 export function setLocalStorageDataCache(value: string) {
     window.localStorage.setItem(LSK.dataCache, value);
 }

--- a/apps/antalmanac/src/stores/SessionStore.ts
+++ b/apps/antalmanac/src/stores/SessionStore.ts
@@ -52,5 +52,7 @@ export const useSessionStore = create<SessionState>((set) => {
         setHasCheckedAuth: (hasCheckedAuth) => set({ hasCheckedAuth }),
         setIsNewUser: (isNewUser) => set({ isNewUser: isNewUser }),
         setAreSchedulesLoaded: (areSchedulesLoaded) => set({ areSchedulesLoaded: areSchedulesLoaded }),
+        setImportedUsername: (username) => set({ importedUsername: username }),
+        clearImportedUsername: () => set({ importedUsername: null }),
     };
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Replaces the `importedUser` localStorage key and the `Header` `useEffect` with in-memory `SessionStore` state.

- Adds `importedUsername`, `setImportedUsername`, and `clearImportedUsername` to `SessionStore`
- `AuthInitializer` sets the flag after guest schedule merge on sign-in
- `Header` derives dialog visibility from `importedUsername && sessionIsValid` (no effect)
- Removes `importedUser` localStorage key and helpers

## Test plan

- [x] `pnpm lint` passes
- [ ] Sign in after loading a guest schedule with unsaved changes — success dialog shows with correct username
- [ ] Dismissing dialog clears the flag (does not reappear on re-render)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b102cf5c-b0ae-4d28-9a41-ef9db872fa19"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b102cf5c-b0ae-4d28-9a41-ef9db872fa19"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

