### PR TITLE
chore: purge stale localStorage keys on auth init

### DIFF
--- a/apps/antalmanac/src/components/AuthInitializer.tsx
+++ b/apps/antalmanac/src/components/AuthInitializer.tsx
@@ -113,8 +113,7 @@ export const AuthInitializer = () => {
             return;
         }
 
-        // Clean up stale localStorage token from before the cookie migration
-        window.localStorage.removeItem('sessionId');
+        removeStaleLocalStorageKeys();
 
         if (sessionData) {
             (async () => {

--- a/apps/antalmanac/src/lib/localStorage.ts
+++ b/apps/antalmanac/src/lib/localStorage.ts
@@ -35,6 +35,23 @@ enum LocalStorageKeys {
 
 const LSK = LocalStorageKeys;
 
+/** Keys from removed features; purged once per session on auth init. */
+const STALE_LOCAL_STORAGE_KEYS = [
+    LSK.recentlySearched,
+    LSK.unsavedActions,
+    LSK.pwaDismissalTime,
+    LSK.sessionId,
+    LSK.newUser,
+    LSK.fromLoading,
+    LSK.importedUser,
+] as const;
+
+export function removeStaleLocalStorageKeys() {
+    for (const key of STALE_LOCAL_STORAGE_KEYS) {
+        window.localStorage.removeItem(key);
+    }
+}
+
 export function setLocalStorageImportedUser(value: string) {
     window.localStorage.setItem(LSK.importedUser, value);
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `removeStaleLocalStorageKeys()` to purge deprecated localStorage keys on auth init, replacing the one-off `sessionId` cleanup.

Purged keys: `recentlySearched`, `unsavedActions`, `pwaDismissalTime`, `sessionId`, `newUser`, `fromLoading`, `importedUser`.

## Test plan

- [x] `pnpm lint` passes
- [ ] Auth init still works for signed-in and guest users
- [ ] Stale keys are removed from localStorage after page load
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b102cf5c-b0ae-4d28-9a41-ef9db872fa19"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b102cf5c-b0ae-4d28-9a41-ef9db872fa19"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

