### PR TITLE
refactor: move guest username and login hint to SessionStore

### DIFF
--- a/apps/antalmanac/src/actions/AppStoreActions.ts
+++ b/apps/antalmanac/src/actions/AppStoreActions.ts
@@ -3,7 +3,7 @@ import { trpc } from '$lib/api/trpc';
 import { getSignInUrl } from '$lib/auth/authActions';
 import { Provider } from '$lib/auth/authTypes';
 import { warnMultipleTerms } from '$lib/helpers';
-import { setLocalStorageUserId, setLocalStorageDataCache } from '$lib/localStorage';
+import { setLocalStorageDataCache } from '$lib/localStorage';
 import { isNativeIosApp } from '$lib/platform';
 import { getErrorMessage } from '$lib/utils';
 import AppStore from '$stores/AppStore';
@@ -292,7 +292,7 @@ export const loadGuestSchedule = async (username: string, rememberMe: boolean, p
         username = username.replace(/\s+/g, '');
         if (username?.length) {
             if (rememberMe) {
-                setLocalStorageUserId(username);
+                useSessionStore.getState().setRememberedGuestUsername(username);
             }
 
             try {

--- a/apps/antalmanac/src/components/AuthInitializer.tsx
+++ b/apps/antalmanac/src/components/AuthInitializer.tsx
@@ -5,13 +5,9 @@ import { trpc } from '$lib/api/trpc';
 import { authClient, signOut } from '$lib/auth/authClient';
 import {
     getLocalStorageDataCache,
-    getLocalStorageUserId,
-    getWasLoggedIn,
     removeLocalStorageDataCache,
     removeLocalStorageImportedUser,
-    removeLocalStorageUserId,
     setLocalStorageImportedUser,
-    setWasLoggedIn,
 } from '$lib/localStorage';
 import { setSsoCookie } from '$lib/ssoCookie';
 import AppStore from '$stores/AppStore';
@@ -31,11 +27,12 @@ export const AuthInitializer = () => {
     const hasInitializedRef = useRef(false);
 
     const setOpenLoadingSchedule = useScheduleComponentsToggleStore((state) => state.setOpenLoadingSchedule);
-    const { updateSession, setAreSchedulesLoaded, setHasCheckedAuth } = useSessionStore(
+    const { updateSession, setAreSchedulesLoaded, setHasCheckedAuth, setWasPreviouslyLoggedIn } = useSessionStore(
         useShallow((state) => ({
             updateSession: state.updateSession,
             setAreSchedulesLoaded: state.setAreSchedulesLoaded,
             setHasCheckedAuth: state.setHasCheckedAuth,
+            setWasPreviouslyLoggedIn: state.setWasPreviouslyLoggedIn,
         }))
     );
 
@@ -65,10 +62,11 @@ export const AuthInitializer = () => {
             return;
         }
 
-        const savedUserId = getLocalStorageUserId();
+        const { rememberedGuestUsername, clearRememberedGuestUsername } = useSessionStore.getState();
+        const savedUserId = rememberedGuestUsername;
         const savedData = getLocalStorageDataCache();
 
-        removeLocalStorageUserId();
+        clearRememberedGuestUsername();
 
         // no changes to save
         if (savedUserId === null && savedData === null) {
@@ -137,7 +135,7 @@ export const AuthInitializer = () => {
                     await loadUnsavedChanges(userData);
 
                     setAreSchedulesLoaded(true);
-                    setWasLoggedIn(true);
+                    setWasPreviouslyLoggedIn(true);
 
                     handleAuthChecked();
                 } catch (error) {
@@ -150,7 +148,7 @@ export const AuthInitializer = () => {
                 handleInitialized();
             })();
         } else {
-            if (getWasLoggedIn()) {
+            if (useSessionStore.getState().wasPreviouslyLoggedIn) {
                 setOpenAlert(true);
             }
             handleAuthChecked();
@@ -164,6 +162,7 @@ export const AuthInitializer = () => {
         postHog,
         setHasCheckedAuth,
         loadPlannerRoadmaps,
+        setWasPreviouslyLoggedIn,
     ]);
 
     return (

--- a/apps/antalmanac/src/components/Header/Import.tsx
+++ b/apps/antalmanac/src/components/Header/Import.tsx
@@ -12,7 +12,7 @@ import analyticsEnum, { logAnalytics } from '$lib/analytics/analytics';
 import { trpc, trpcReact } from '$lib/api/trpc';
 import { QueryZotcourseError } from '$lib/customErrors';
 import { warnMultipleTerms } from '$lib/helpers';
-import { getLocalStorageDataCache, getLocalStorageUserId, removeLocalStorageUserId } from '$lib/localStorage';
+import { getLocalStorageDataCache } from '$lib/localStorage';
 import { processZotcourseResponse } from '$lib/zotcourse';
 import { BLUE, LIGHT_BLUE } from '$src/globals';
 import AppStore from '$stores/AppStore';
@@ -653,11 +653,11 @@ export function Import() {
 
     const handleFirstTimeSignin = useCallback(async () => {
         if (areSchedulesLoaded && isNewUser) {
-            const savedUserId = getLocalStorageUserId();
+            const savedUserId = useSessionStore.getState().rememberedGuestUsername;
             if (savedUserId) setAAUsername(savedUserId);
             handleOpen();
             setIsNewUser(false);
-            removeLocalStorageUserId();
+            useSessionStore.getState().clearRememberedGuestUsername();
             setImportSource(ImportSource.AA_USERNAME_IMPORT);
         }
     }, [handleOpen, isNewUser, setIsNewUser, areSchedulesLoaded]);

--- a/apps/antalmanac/src/components/Header/Signin.tsx
+++ b/apps/antalmanac/src/components/Header/Signin.tsx
@@ -5,8 +5,8 @@ import { ProfileMenuButtons } from '$components/Header/ProfileMenuButtons';
 import { SettingsMenu } from '$components/Header/Settings/SettingsMenu';
 import { SignInAlertDialog } from '$components/SignInAlertDialog';
 import { trpc } from '$lib/api/trpc';
-import { getLocalStorageUserId } from '$lib/localStorage';
 import { useScheduleComponentsToggleStore } from '$stores/ScheduleComponentsToggleStore';
+import { useSessionStore } from '$stores/SessionStore';
 import { useThemeStore } from '$stores/SettingsStore';
 import { AccountCircle, ExpandMore } from '@mui/icons-material';
 import {
@@ -53,11 +53,9 @@ export const Signin = () => {
     const handleOpen = useCallback(() => {
         setIsOpen(true);
         setSettingsAnchorEl(null);
-        if (typeof Storage !== 'undefined') {
-            const savedUserID = getLocalStorageUserId();
-            if (savedUserID !== null) {
-                setUserID(savedUserID);
-            }
+        const savedUserID = useSessionStore.getState().rememberedGuestUsername;
+        if (savedUserID !== null) {
+            setUserID(savedUserID);
         }
     }, []);
 

--- a/apps/antalmanac/src/components/ScheduleManagement/ScheduleManagement.tsx
+++ b/apps/antalmanac/src/components/ScheduleManagement/ScheduleManagement.tsx
@@ -4,7 +4,6 @@ import { readCourseSearchParams, readSearchMode } from '$components/RightPane/Co
 import { ScheduleManagementContent } from '$components/ScheduleManagement/ScheduleManagementContent';
 import { ScheduleManagementTabs } from '$components/ScheduleManagement/ScheduleManagementTabs';
 import { useIsMobile } from '$hooks/useIsMobile';
-import { getWasLoggedIn } from '$lib/localStorage';
 import { shouldSearchPlannerFromParams } from '$lib/plannerHelpers';
 import AppStore from '$stores/AppStore';
 import { useSavedSearchStore } from '$stores/SavedSearchStore';
@@ -92,10 +91,12 @@ export function ScheduleManagement() {
         } else if (hasParams || isManualSearchMode) {
             setActiveTab('search');
         } else if (!isMobile) {
-            const hasSession = useSessionStore.getState().sessionIsValid || getWasLoggedIn();
+            const hasSession =
+                useSessionStore.getState().sessionIsValid || useSessionStore.getState().wasPreviouslyLoggedIn;
             setActiveTab(hasSession ? 'added' : 'search');
         } else {
-            const hasSession = useSessionStore.getState().sessionIsValid || getWasLoggedIn();
+            const hasSession =
+                useSessionStore.getState().sessionIsValid || useSessionStore.getState().wasPreviouslyLoggedIn;
             const hasLocalScheduleData = AppStore.getAddedCourses().length > 0 || AppStore.getCustomEvents().length > 0;
 
             if (hasSession || hasLocalScheduleData) {

--- a/apps/antalmanac/src/lib/TutorialHelpers.tsx
+++ b/apps/antalmanac/src/lib/TutorialHelpers.tsx
@@ -1,8 +1,9 @@
 import { addSampleClasses } from '$lib/tourExampleGeneration';
+import { useSessionStore } from '$stores/SessionStore';
 import { useTabStore } from '$stores/TabStore';
 import { StepType } from '@reactour/tour';
 
-import { getLocalStorageTourHasRun, getLocalStorageUserId, setLocalStorageTourHasRun } from './localStorage';
+import { getLocalStorageTourHasRun, setLocalStorageTourHasRun } from './localStorage';
 
 enum TourStepName {
     welcome = 'welcome',
@@ -70,7 +71,7 @@ export function tourShouldRun(): boolean {
     return !(
         getLocalStorageTourHasRun() == 'true' ||
         window.matchMedia('(max-width: 799px)').matches ||
-        getLocalStorageUserId() != null
+        useSessionStore.getState().rememberedGuestUsername != null
     );
 }
 

--- a/apps/antalmanac/src/lib/auth/authClient.ts
+++ b/apps/antalmanac/src/lib/auth/authClient.ts
@@ -1,9 +1,9 @@
 import analyticsEnum, { logAnalytics } from '$lib/analytics/analytics';
 import { getSignOutUrl } from '$lib/auth/authActions';
-import { setWasLoggedIn } from '$lib/localStorage';
 import { clearSsoCookie } from '$lib/ssoCookie';
 import { getErrorMessage } from '$lib/utils';
 import type { auth } from '$src/lib/auth/auth';
+import { useSessionStore } from '$stores/SessionStore';
 import { openSnackbar } from '$stores/SnackbarStore';
 import { genericOAuthClient, inferAdditionalFields } from 'better-auth/client/plugins';
 import { createAuthClient } from 'better-auth/react';
@@ -35,7 +35,7 @@ export async function signOut({ onLogoutComplete, postHog }: SignOutOptions = {}
     }
 
     clearSsoCookie();
-    setWasLoggedIn(false);
+    useSessionStore.getState().setWasPreviouslyLoggedIn(false);
     onLogoutComplete?.();
 
     const { error } = await authClient.signOut();

--- a/apps/antalmanac/src/lib/localStorage.ts
+++ b/apps/antalmanac/src/lib/localStorage.ts
@@ -1,6 +1,5 @@
 enum LocalStorageKeys {
     /* The case-difference is due to the original implementation */
-    userId = 'userID',
     patchNotesKey = 'latestPatchSeen',
     recruitmentDismissalTime = 'recruitmentDismissalTime',
     tourHasRun = 'tourHasRun',
@@ -12,7 +11,6 @@ enum LocalStorageKeys {
     autoSave = 'autoSave',
     devMode = 'devMode',
     columnToggles = 'columnToggles',
-    wasLoggedIn = 'wasLoggedIn',
     dataCache = 'dataCache',
     importedUser = 'importedUser',
     tempSaveData = 'tempSaveData',
@@ -57,30 +55,6 @@ export function getLocalStorageDataCache() {
 
 export function removeLocalStorageDataCache() {
     window.localStorage.removeItem(LSK.dataCache);
-}
-
-export function setLocalStorageUserId(value: string) {
-    window.localStorage.setItem(LSK.userId, value);
-}
-
-export function getLocalStorageUserId() {
-    return window.localStorage.getItem(LSK.userId);
-}
-
-export function removeLocalStorageUserId() {
-    window.localStorage.removeItem(LSK.userId);
-}
-
-export function getWasLoggedIn(): boolean {
-    return window.localStorage.getItem(LSK.wasLoggedIn) === 'true';
-}
-
-export function setWasLoggedIn(value: boolean) {
-    if (value) {
-        window.localStorage.setItem(LSK.wasLoggedIn, 'true');
-    } else {
-        window.localStorage.removeItem(LSK.wasLoggedIn);
-    }
 }
 
 // Helper functions for patchNotesKey

--- a/apps/antalmanac/src/stores/SessionStore.ts
+++ b/apps/antalmanac/src/stores/SessionStore.ts
@@ -1,5 +1,9 @@
 import { SessionData } from '$lib/auth/authClient';
 import { create } from 'zustand';
+import { createJSONStorage, persist } from 'zustand/middleware';
+
+const LEGACY_USER_ID_KEY = 'userID';
+const LEGACY_WAS_LOGGED_IN_KEY = 'wasLoggedIn';
 
 interface SessionState {
     session: SessionData['session'] | null;
@@ -20,37 +24,95 @@ interface SessionState {
 
     areSchedulesLoaded: boolean;
     setAreSchedulesLoaded: (areSchedulesLoaded: boolean) => void;
+
+    /** Guest username from "remember me" on legacy load flow. */
+    rememberedGuestUsername: string | null;
+    setRememberedGuestUsername: (username: string) => void;
+    clearRememberedGuestUsername: () => void;
+
+    /** Whether the user had a valid session before the current page load. */
+    wasPreviouslyLoggedIn: boolean;
+    setWasPreviouslyLoggedIn: (value: boolean) => void;
 }
 
-export const useSessionStore = create<SessionState>((set) => {
-    return {
-        session: null,
-        sessionId: null,
-        user: null,
-        userId: null,
-        email: null,
-        name: null,
-        avatar: null,
-        sessionIsValid: false,
-        hasCheckedAuth: false,
-        isNewUser: false,
-        areSchedulesLoaded: false,
+function migrateLegacySessionKeys(): Pick<SessionState, 'rememberedGuestUsername' | 'wasPreviouslyLoggedIn'> {
+    if (typeof window === 'undefined') {
+        return { rememberedGuestUsername: null, wasPreviouslyLoggedIn: false };
+    }
 
-        updateSession: async (sessionData: SessionData) => {
-            set({
-                session: sessionData.session,
-                sessionId: sessionData.session.id,
-                user: sessionData.user,
-                userId: sessionData.user.id,
-                sessionIsValid: true,
-                email: sessionData.user.email,
-                name: sessionData.user.name,
-                avatar: sessionData.user.avatar,
-            });
-        },
+    let rememberedGuestUsername: string | null = null;
+    let wasPreviouslyLoggedIn = false;
 
-        setHasCheckedAuth: (hasCheckedAuth) => set({ hasCheckedAuth }),
-        setIsNewUser: (isNewUser) => set({ isNewUser: isNewUser }),
-        setAreSchedulesLoaded: (areSchedulesLoaded) => set({ areSchedulesLoaded: areSchedulesLoaded }),
-    };
-});
+    const legacyUserId = window.localStorage.getItem(LEGACY_USER_ID_KEY);
+    if (legacyUserId) {
+        rememberedGuestUsername = legacyUserId;
+        window.localStorage.removeItem(LEGACY_USER_ID_KEY);
+    }
+
+    if (window.localStorage.getItem(LEGACY_WAS_LOGGED_IN_KEY) === 'true') {
+        wasPreviouslyLoggedIn = true;
+        window.localStorage.removeItem(LEGACY_WAS_LOGGED_IN_KEY);
+    }
+
+    return { rememberedGuestUsername, wasPreviouslyLoggedIn };
+}
+
+export const useSessionStore = create<SessionState>()(
+    persist(
+        (set) => ({
+            session: null,
+            sessionId: null,
+            user: null,
+            userId: null,
+            email: null,
+            name: null,
+            avatar: null,
+            sessionIsValid: false,
+            hasCheckedAuth: false,
+            isNewUser: false,
+            areSchedulesLoaded: false,
+            rememberedGuestUsername: null,
+            wasPreviouslyLoggedIn: false,
+
+            updateSession: async (sessionData: SessionData) => {
+                set({
+                    session: sessionData.session,
+                    sessionId: sessionData.session.id,
+                    user: sessionData.user,
+                    userId: sessionData.user.id,
+                    sessionIsValid: true,
+                    email: sessionData.user.email,
+                    name: sessionData.user.name,
+                    avatar: sessionData.user.avatar,
+                });
+            },
+
+            setHasCheckedAuth: (hasCheckedAuth) => set({ hasCheckedAuth }),
+            setIsNewUser: (isNewUser) => set({ isNewUser: isNewUser }),
+            setAreSchedulesLoaded: (areSchedulesLoaded) => set({ areSchedulesLoaded: areSchedulesLoaded }),
+            setRememberedGuestUsername: (username) => set({ rememberedGuestUsername: username }),
+            clearRememberedGuestUsername: () => set({ rememberedGuestUsername: null }),
+            setWasPreviouslyLoggedIn: (value) => set({ wasPreviouslyLoggedIn: value }),
+        }),
+        {
+            name: 'aa-session',
+            storage: createJSONStorage(() => localStorage),
+            partialize: (state) => ({
+                rememberedGuestUsername: state.rememberedGuestUsername,
+                wasPreviouslyLoggedIn: state.wasPreviouslyLoggedIn,
+            }),
+            merge: (persisted, current) => {
+                const legacy = migrateLegacySessionKeys();
+                const stored = persisted as Partial<
+                    Pick<SessionState, 'rememberedGuestUsername' | 'wasPreviouslyLoggedIn'>
+                >;
+
+                return {
+                    ...current,
+                    rememberedGuestUsername: stored.rememberedGuestUsername ?? legacy.rememberedGuestUsername,
+                    wasPreviouslyLoggedIn: stored.wasPreviouslyLoggedIn ?? legacy.wasPreviouslyLoggedIn,
+                };
+            },
+        }
+    )
+);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Moves `userID` and `wasLoggedIn` localStorage usage into `SessionStore` with zustand `persist`.

- Adds `rememberedGuestUsername` and `wasPreviouslyLoggedIn` with setters
- Migrates legacy `userID` / `wasLoggedIn` keys on store rehydrate
- Updates `AuthInitializer`, `Import`, `Signin`, `ScheduleManagement`, `authClient`, and `TutorialHelpers`
- Removes `get/set/removeLocalStorageUserId` and `get/setWasLoggedIn` helpers

## Test plan

- [x] `pnpm lint` passes
- [ ] Guest load with "remember me" pre-fills username after reload
- [ ] Sign-in after guest edits merges schedule and shows success flow
- [ ] Session-expired dialog appears for returning users with stale session
- [ ] Sign-out clears `wasPreviouslyLoggedIn`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b102cf5c-b0ae-4d28-9a41-ef9db872fa19"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b102cf5c-b0ae-4d28-9a41-ef9db872fa19"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

