### PR TITLE
chore: standardize path aliases and component exports

### DIFF
--- a/apps/antalmanac/next.config.ts
+++ b/apps/antalmanac/next.config.ts
@@ -22,11 +22,6 @@ const nextConfig: NextConfig = {
                 destination: '/api/auth/oauth2/callback/icssc',
                 permanent: false,
             },
-            {
-                source: '/assets/:path*',
-                destination: '/logos/:path*',
-                permanent: true,
-            },
         ];
     },
     async rewrites() {

--- a/apps/antalmanac/scripts/get-search-data.ts
+++ b/apps/antalmanac/scripts/get-search-data.ts
@@ -1,10 +1,10 @@
 import { access, mkdir, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 
+import { parseSectionCodes, type SectionCodesGraphQLResponse } from '$backend/lib/term-section-codes';
 import { termData } from '$lib/term';
 import { canTermEnrollmentChange } from '$lib/termHelpers';
 import { env } from '$scripts/env';
-import { parseSectionCodes, type SectionCodesGraphQLResponse } from '$src/backend/lib/term-section-codes';
 import type { AATerm, CourseSearchResult, DepartmentSearchResult } from '@packages/antalmanac-types';
 import { createClient } from '@packages/anteater-api/client';
 import type { Course, WebsocAPIResponse, WebsocCourse, WebsocDepartment } from '@packages/anteater-api/types';

--- a/apps/antalmanac/scripts/get-search-data.ts
+++ b/apps/antalmanac/scripts/get-search-data.ts
@@ -4,11 +4,11 @@ import { join } from 'node:path';
 import { termData } from '$lib/term';
 import { canTermEnrollmentChange } from '$lib/termHelpers';
 import { env } from '$scripts/env';
+import { parseSectionCodes, type SectionCodesGraphQLResponse } from '$src/backend/lib/term-section-codes';
 import type { AATerm, CourseSearchResult, DepartmentSearchResult } from '@packages/antalmanac-types';
 import { createClient } from '@packages/anteater-api/client';
 import type { Course, WebsocAPIResponse, WebsocCourse, WebsocDepartment } from '@packages/anteater-api/types';
 
-import { parseSectionCodes, type SectionCodesGraphQLResponse } from '../src/backend/lib/term-section-codes';
 import { GENERATED_DIR, GENERATED_TERMS_DIR, SEARCH_DATA_FILE } from './lib/paths.js';
 
 const aapiClient = createClient({ apiKey: env.ANTEATER_API_KEY });

--- a/apps/antalmanac/scripts/update-terms.ts
+++ b/apps/antalmanac/scripts/update-terms.ts
@@ -1,12 +1,12 @@
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import { dirname } from 'node:path';
 
+import { parseTermShortName } from '$lib/termHelpers';
 import { env } from '$scripts/env';
 import { createClient } from '@packages/anteater-api/client';
 import type { WebsocTerm } from '@packages/anteater-api/types';
 import { flattenSections } from '@packages/anteater-api/utils';
 
-import { parseTermShortName } from '../src/lib/termHelpers.js';
 import { DEPLOYED_TERMS_FILE } from './lib/paths.js';
 
 interface DeployedTermsData {

--- a/apps/antalmanac/src/app/[[...slug]]/client.tsx
+++ b/apps/antalmanac/src/app/[[...slug]]/client.tsx
@@ -2,7 +2,7 @@
 
 import dynamic from 'next/dynamic';
 
-const App = dynamic(() => import('../../App'), { ssr: false });
+const App = dynamic(() => import('$src/App'), { ssr: false });
 
 export function ClientOnly() {
     return <App />;

--- a/apps/antalmanac/src/app/api/trpc/[trpc]/route.ts
+++ b/apps/antalmanac/src/app/api/trpc/[trpc]/route.ts
@@ -1,7 +1,6 @@
+import { createContext } from '$backend/context';
+import appRouter from '$backend/routers';
 import { fetchRequestHandler } from '@trpc/server/adapters/fetch';
-
-import { createContext } from '$src/backend/context';
-import appRouter from '$src/backend/routers';
 
 const handler = (req: Request) =>
     fetchRequestHandler({

--- a/apps/antalmanac/src/backend/lib/aapi.ts
+++ b/apps/antalmanac/src/backend/lib/aapi.ts
@@ -1,8 +1,7 @@
+import { middleware, procedure } from '$backend/trpc';
 import { env } from '$src/env';
 import { AAPIError, createClient } from '@packages/anteater-api/client';
 import { TRPCError } from '@trpc/server';
-
-import { middleware, procedure } from '../trpc';
 
 export const aapiClient = createClient({ apiKey: env.ANTEATER_API_KEY });
 

--- a/apps/antalmanac/src/backend/lib/rds/friendships.ts
+++ b/apps/antalmanac/src/backend/lib/rds/friendships.ts
@@ -1,7 +1,6 @@
+import type { DatabaseOrTransaction } from '$backend/lib/rds/types';
 import { friendships, users } from '@packages/db/src/schema';
 import { and, eq, ne, or } from 'drizzle-orm';
-
-import type { DatabaseOrTransaction } from './types';
 
 /**
  * Returns all friendship rows between two users regardless of direction.

--- a/apps/antalmanac/src/backend/lib/rds/helpers.ts
+++ b/apps/antalmanac/src/backend/lib/rds/helpers.ts
@@ -1,3 +1,4 @@
+import type { DatabaseOrTransaction } from '$backend/lib/rds/types';
 import { VisibilityState, VISIBILITY_STATES, type ShortCourseSchedule } from '@packages/antalmanac-types';
 import {
     coursesInSchedule,
@@ -8,8 +9,6 @@ import {
     type Schedule,
 } from '@packages/db/src/schema';
 import { eq, type SQL } from 'drizzle-orm';
-
-import type { DatabaseOrTransaction } from './types';
 
 /**
  * Loads schedules matching the given condition with courses and custom events joined in parallel.

--- a/apps/antalmanac/src/backend/lib/rds/notifications.ts
+++ b/apps/antalmanac/src/backend/lib/rds/notifications.ts
@@ -1,10 +1,9 @@
+import type { DatabaseOrTransaction } from '$backend/lib/rds/types';
 import type { Notification } from '@packages/antalmanac-types';
 import type { Quarter, Year } from '@packages/anteater-api/types';
 import { subscriptions } from '@packages/db/src/schema';
 import { buildConflictUpdateSet } from '@packages/db/src/utils';
 import { and, eq } from 'drizzle-orm';
-
-import type { DatabaseOrTransaction } from './types';
 
 /**
  * Retrieves notifications associated with a specified user and environment.

--- a/apps/antalmanac/src/backend/lib/rds/reviews.ts
+++ b/apps/antalmanac/src/backend/lib/rds/reviews.ts
@@ -1,7 +1,6 @@
+import type { DatabaseOrTransaction } from '$backend/lib/rds/types';
 import { instructorReviews, type NewInstructorReview, reviewDismissals } from '@packages/db/src/schema';
 import { eq, max } from 'drizzle-orm';
-
-import type { DatabaseOrTransaction } from './types';
 
 export async function insertInstructorReview(
     db: DatabaseOrTransaction,

--- a/apps/antalmanac/src/backend/lib/rds/schedules.ts
+++ b/apps/antalmanac/src/backend/lib/rds/schedules.ts
@@ -1,3 +1,5 @@
+import { loadSchedules } from '$backend/lib/rds/helpers';
+import type { DatabaseOrTransaction, Transaction } from '$backend/lib/rds/types';
 import {
     VisibilityState,
     type ShortCourse,
@@ -13,9 +15,6 @@ import {
 } from '@packages/db/src/utils';
 import { createId } from '@paralleldrive/cuid2';
 import { and, eq, not, notInArray, or } from 'drizzle-orm';
-
-import { loadSchedules } from './helpers';
-import type { DatabaseOrTransaction, Transaction } from './types';
 
 /**
  * Upserts the given user's schedules and selected schedule index.

--- a/apps/antalmanac/src/backend/lib/rds/users.ts
+++ b/apps/antalmanac/src/backend/lib/rds/users.ts
@@ -1,9 +1,8 @@
+import { loadSchedules } from '$backend/lib/rds/helpers';
+import type { DatabaseOrTransaction } from '$backend/lib/rds/types';
 import type { ScheduleSaveState } from '@packages/antalmanac-types';
 import { accounts, schedules, users, type User } from '@packages/db/src/schema';
 import { and, eq, sql } from 'drizzle-orm';
-
-import { loadSchedules } from './helpers';
-import type { DatabaseOrTransaction } from './types';
 
 export async function getUserByEmail(db: DatabaseOrTransaction, email: string) {
     return db

--- a/apps/antalmanac/src/backend/routers/course.ts
+++ b/apps/antalmanac/src/backend/routers/course.ts
@@ -1,11 +1,10 @@
+import { aapiClient, aapiProcedure } from '$backend/lib/aapi';
+import { router } from '$backend/trpc';
 import { getRenamedCoursesIdentifiers } from '$lib/renames/utils';
-import { aapiClient, aapiProcedure } from '$src/backend/lib/aapi';
 import { AAPIError } from '@packages/anteater-api/client';
 import type { Course, CoursesBatchAPIResult } from '@packages/anteater-api/types';
 import { TRPCError } from '@trpc/server';
 import { z } from 'zod';
-
-import { router } from '../trpc';
 
 const courseRouter = router({
     get: aapiProcedure

--- a/apps/antalmanac/src/backend/routers/enrollHist.ts
+++ b/apps/antalmanac/src/backend/routers/enrollHist.ts
@@ -1,10 +1,9 @@
+import { aapiClient, aapiProcedure } from '$backend/lib/aapi';
+import { router } from '$backend/trpc';
 import { getRenamedCoursesIdentifiers } from '$lib/renames/utils';
-import { aapiClient, aapiProcedure } from '$src/backend/lib/aapi';
 import { WebsocSectionTypeSchema } from '@packages/antalmanac-types';
 import type { EnrollmentHistoryEntry } from '@packages/anteater-api/types';
 import { z } from 'zod';
-
-import { router } from '../trpc';
 
 const enrollHistRouter = router({
     get: aapiProcedure

--- a/apps/antalmanac/src/backend/routers/friends.ts
+++ b/apps/antalmanac/src/backend/routers/friends.ts
@@ -10,10 +10,10 @@ import {
     getSentPendingRequests,
     insertFriendRequest,
     unblockUser,
-} from '$src/backend/lib/rds/friendships';
-import { getScheduleSharingStatuses, toggleScheduleSharing } from '$src/backend/lib/rds/schedules';
-import { getUserByEmail } from '$src/backend/lib/rds/users';
-import { protectedProcedure, router } from '$src/backend/trpc';
+} from '$backend/lib/rds/friendships';
+import { getScheduleSharingStatuses, toggleScheduleSharing } from '$backend/lib/rds/schedules';
+import { getUserByEmail } from '$backend/lib/rds/users';
+import { protectedProcedure, router } from '$backend/trpc';
 import { db } from '@packages/db';
 import { TRPCError } from '@trpc/server';
 import { z } from 'zod';

--- a/apps/antalmanac/src/backend/routers/grades.ts
+++ b/apps/antalmanac/src/backend/routers/grades.ts
@@ -1,11 +1,10 @@
+import { aapiClient, aapiProcedure } from '$backend/lib/aapi';
+import { router } from '$backend/trpc';
 import { getRenamedCoursesIdentifiers, mergeAggregateGrades } from '$lib/renames/utils';
-import { aapiClient, aapiProcedure } from '$src/backend/lib/aapi';
-import { isNotEmpty } from '$src/lib/utils';
+import { isNotEmpty } from '$lib/utils';
 import { GradesGeSchema } from '@packages/antalmanac-types';
 import type { AggregateGrades, AggregateGradesByOffering } from '@packages/anteater-api/types';
 import { z } from 'zod';
-
-import { router } from '../trpc';
 
 const gradesRouter = router({
     aggregateGrades: aapiProcedure

--- a/apps/antalmanac/src/backend/routers/index.ts
+++ b/apps/antalmanac/src/backend/routers/index.ts
@@ -1,15 +1,15 @@
-import { router } from '../trpc';
-import courseRouter from './course';
-import enrollHistRouter from './enrollHist';
-import friendsRouter from './friends';
-import gradesRouter from './grades';
-import notificationsRouter from './notifications';
-import reviewRouter from './review';
-import roadmapRouter from './roadmap';
-import scheduleRouter from './schedule';
-import searchRouter from './search';
-import websocRouter from './websoc';
-import zotcourseRouter from './zotcourse';
+import courseRouter from '$backend/routers/course';
+import enrollHistRouter from '$backend/routers/enrollHist';
+import friendsRouter from '$backend/routers/friends';
+import gradesRouter from '$backend/routers/grades';
+import notificationsRouter from '$backend/routers/notifications';
+import reviewRouter from '$backend/routers/review';
+import roadmapRouter from '$backend/routers/roadmap';
+import scheduleRouter from '$backend/routers/schedule';
+import searchRouter from '$backend/routers/search';
+import websocRouter from '$backend/routers/websoc';
+import zotcourseRouter from '$backend/routers/zotcourse';
+import { router } from '$backend/trpc';
 
 const appRouter = router({
     course: courseRouter,

--- a/apps/antalmanac/src/backend/routers/notifications.ts
+++ b/apps/antalmanac/src/backend/routers/notifications.ts
@@ -4,8 +4,8 @@ import {
     retrieveNotifications,
     updateAllNotifications,
     upsertNotification,
-} from '$src/backend/lib/rds/notifications';
-import { procedure, protectedProcedure, router } from '$src/backend/trpc';
+} from '$backend/lib/rds/notifications';
+import { procedure, protectedProcedure, router } from '$backend/trpc';
 import { env } from '$src/env';
 import { QuarterSchema, WebsocSectionStatusSchema, WebsocSectionTypeSchema } from '@packages/antalmanac-types';
 import { db } from '@packages/db';

--- a/apps/antalmanac/src/backend/routers/review.ts
+++ b/apps/antalmanac/src/backend/routers/review.ts
@@ -4,12 +4,11 @@ import {
     getReviewedCombos,
     insertInstructorReview,
     insertReviewDismissal,
-} from '$src/backend/lib/rds/reviews';
+} from '$backend/lib/rds/reviews';
+import { protectedProcedure, router } from '$backend/trpc';
 import { db } from '@packages/db';
 import { TRPCError } from '@trpc/server';
 import { z } from 'zod';
-
-import { protectedProcedure, router } from '../trpc';
 
 const reviewTagsEnum = z.enum([
     'Textbook Required',

--- a/apps/antalmanac/src/backend/routers/roadmap.ts
+++ b/apps/antalmanac/src/backend/routers/roadmap.ts
@@ -1,4 +1,4 @@
-import { protectedProcedure, router } from '$src/backend/trpc';
+import { protectedProcedure, router } from '$backend/trpc';
 import { env } from '$src/env';
 import type { Roadmap } from '@packages/antalmanac-types';
 import { headers } from 'next/headers';

--- a/apps/antalmanac/src/backend/routers/schedule.ts
+++ b/apps/antalmanac/src/backend/routers/schedule.ts
@@ -1,12 +1,12 @@
-import { areFriends } from '$src/backend/lib/rds/friendships';
-import { getScheduleById, upsertUserData } from '$src/backend/lib/rds/schedules';
+import { areFriends } from '$backend/lib/rds/friendships';
+import { getScheduleById, upsertUserData } from '$backend/lib/rds/schedules';
 import {
     fetchUserDataByUserId,
     flagImportedUser,
     getGuestScheduleByUsername,
     getUserFriendDataByUid,
-} from '$src/backend/lib/rds/users';
-import { procedure, protectedProcedure, router } from '$src/backend/trpc';
+} from '$backend/lib/rds/users';
+import { procedure, protectedProcedure, router } from '$backend/trpc';
 import { type ScheduleSaveState, ScheduleSaveStateSchema } from '@packages/antalmanac-types';
 import { db } from '@packages/db';
 import { TRPCError } from '@trpc/server';

--- a/apps/antalmanac/src/backend/routers/search.ts
+++ b/apps/antalmanac/src/backend/routers/search.ts
@@ -1,6 +1,7 @@
 import { readFile } from 'fs/promises';
 import { join } from 'node:path';
 
+import { procedure, router } from '$backend/trpc';
 // eslint-disable-next-line import/no-unresolved
 import _searchData from '$generated/searchData.json';
 import {
@@ -11,8 +12,6 @@ import {
 } from '@packages/antalmanac-types';
 import * as fuzzysort from 'fuzzysort';
 import { z } from 'zod';
-
-import { procedure, router } from '../trpc';
 
 const departmentSchema = z.object({
     id: z.string(),

--- a/apps/antalmanac/src/backend/routers/websoc.ts
+++ b/apps/antalmanac/src/backend/routers/websoc.ts
@@ -1,5 +1,6 @@
+import { aapiClient, aapiProcedure } from '$backend/lib/aapi';
+import { router } from '$backend/trpc';
 import { getRenamedCoursesIdentifiers } from '$lib/renames/utils';
-import { aapiClient, aapiProcedure } from '$src/backend/lib/aapi';
 import {
     QuarterSchema,
     WebsocSearchInputKeysSchema,
@@ -15,8 +16,6 @@ import type {
 } from '@packages/anteater-api/types';
 import { sortWebsocResponse, unionWebsocResponses } from '@packages/anteater-api/utils';
 import { z } from 'zod';
-
-import { router } from '../trpc';
 
 function sanitizeWebsocParams(params: WebsocSearchInput): WebsocQueryParams {
     const { department, courseNumber, excludeRestrictionCodes, days, ...rest } = params;

--- a/apps/antalmanac/src/backend/routers/zotcourse.ts
+++ b/apps/antalmanac/src/backend/routers/zotcourse.ts
@@ -1,6 +1,5 @@
+import { procedure, router } from '$backend/trpc';
 import { z } from 'zod';
-
-import { procedure, router } from '../trpc';
 
 const zotcourseUrl = 'https://zotcourse.appspot.com/schedule/load';
 

--- a/apps/antalmanac/src/backend/trpc.ts
+++ b/apps/antalmanac/src/backend/trpc.ts
@@ -1,4 +1,4 @@
-import type { Context } from '$src/backend/context';
+import type { Context } from '$backend/context';
 import { initTRPC, TRPCError } from '@trpc/server';
 import superjson from 'superjson';
 

--- a/apps/antalmanac/src/components/Calendar/CalendarEvent/CalendarEventDetail.tsx
+++ b/apps/antalmanac/src/components/Calendar/CalendarEvent/CalendarEventDetail.tsx
@@ -2,7 +2,7 @@ import { deleteCourse, deleteCustomEvent } from '$actions/AppStoreActions';
 import { MapLink } from '$components/buttons/MapLink';
 import { CustomEventDialog } from '$components/Calendar/Toolbar/CustomEventDialog/CustomEventDialog';
 import { isCourseEvent, type CourseEvent, type CustomEvent } from '$components/Calendar/types';
-import ColorPicker from '$components/ColorPicker';
+import { ColorPicker } from '$components/ColorPicker';
 import { useQuickSearch } from '$hooks/useQuickSearch';
 import analyticsEnum, { logAnalytics } from '$lib/analytics/analytics';
 import { clickToCopy } from '$lib/helpers';

--- a/apps/antalmanac/src/components/Calendar/Toolbar/CalendarToolbar.tsx
+++ b/apps/antalmanac/src/components/Calendar/Toolbar/CalendarToolbar.tsx
@@ -1,7 +1,7 @@
 import { redoAction, undoDelete } from '$actions/AppStoreActions';
 import { ClearScheduleButton } from '$components/buttons/Clear';
-import DownloadButton from '$components/buttons/Download';
-import ScreenshotButton from '$components/buttons/Screenshot';
+import { DownloadButton } from '$components/buttons/Download';
+import { ScreenshotButton } from '$components/buttons/Screenshot';
 import { CustomEventDialog } from '$components/Calendar/Toolbar/CustomEventDialog/CustomEventDialog';
 import { SelectSchedulePopover } from '$components/Calendar/Toolbar/ScheduleSelect/ScheduleSelect';
 import { useIsMobile } from '$hooks/useIsMobile';

--- a/apps/antalmanac/src/components/Calendar/Toolbar/ScheduleSelect/schedule-select-buttons/AddScheduleButton.tsx
+++ b/apps/antalmanac/src/components/Calendar/Toolbar/ScheduleSelect/schedule-select-buttons/AddScheduleButton.tsx
@@ -1,4 +1,4 @@
-import AddScheduleDialog from '$components/dialogs/AddSchedule';
+import { AddScheduleDialog } from '$components/dialogs/AddSchedule';
 import { useFallbackStore } from '$stores/FallbackStore';
 import { Add as AddIcon } from '@mui/icons-material';
 import { Box, Button, Typography } from '@mui/material';

--- a/apps/antalmanac/src/components/Calendar/Toolbar/ScheduleSelect/schedule-select-buttons/DeleteScheduleButton.tsx
+++ b/apps/antalmanac/src/components/Calendar/Toolbar/ScheduleSelect/schedule-select-buttons/DeleteScheduleButton.tsx
@@ -1,4 +1,4 @@
-import DeleteScheduleDialog from '$components/dialogs/DeleteSchedule';
+import { DeleteScheduleDialog } from '$components/dialogs/DeleteSchedule';
 import AppStore from '$stores/AppStore';
 import { useFallbackStore } from '$stores/FallbackStore';
 import { Clear as ClearIcon } from '@mui/icons-material';

--- a/apps/antalmanac/src/components/Calendar/Toolbar/ScheduleSelect/schedule-select-buttons/RenameScheduleButton.tsx
+++ b/apps/antalmanac/src/components/Calendar/Toolbar/ScheduleSelect/schedule-select-buttons/RenameScheduleButton.tsx
@@ -1,4 +1,4 @@
-import RenameScheduleDialog from '$components/dialogs/RenameSchedule';
+import { RenameScheduleDialog } from '$components/dialogs/RenameSchedule';
 import { useFallbackStore } from '$stores/FallbackStore';
 import { Edit as EditIcon } from '@mui/icons-material';
 import { IconButton, Tooltip } from '@mui/material';

--- a/apps/antalmanac/src/components/ColorPicker.tsx
+++ b/apps/antalmanac/src/components/ColorPicker.tsx
@@ -25,7 +25,7 @@ interface ColorPickerProps {
     sectionCode?: string;
 }
 
-const ColorPicker = memo(function ColorPicker({
+export const ColorPicker = memo(function ColorPicker({
     color,
     analyticsCategory,
     isCustomEvent,
@@ -157,5 +157,3 @@ const ColorPicker = memo(function ColorPicker({
         </>
     );
 });
-
-export default ColorPicker;

--- a/apps/antalmanac/src/components/PatchNotes.tsx
+++ b/apps/antalmanac/src/components/PatchNotes.tsx
@@ -27,7 +27,7 @@ function PatchNotesBackdrop(props: BackdropProps) {
 /**
  * PatchNotes follows structure/layout of AboutPage.tsx
  */
-function PatchNotes() {
+export function PatchNotes() {
     const [showPatchNotes, setShowPatchNotes] = usePatchNotesStore(
         useShallow((store) => [store.showPatchNotes, store.setShowPatchNotes])
     );
@@ -125,8 +125,6 @@ function PatchNotes() {
         </Dialog>
     );
 }
-
-export default PatchNotes;
 
 /* Used for Tests */
 export const dialogTestId = 'patch-notes-dialog';

--- a/apps/antalmanac/src/components/RightPane/AddedCourses/CustomEventDetailView.tsx
+++ b/apps/antalmanac/src/components/RightPane/AddedCourses/CustomEventDetailView.tsx
@@ -1,7 +1,7 @@
 import { deleteCustomEvent } from '$actions/AppStoreActions';
 import { MapLink } from '$components/buttons/MapLink';
 import { CustomEventDialog } from '$components/Calendar/Toolbar/CustomEventDialog/CustomEventDialog';
-import ColorPicker from '$components/ColorPicker';
+import { ColorPicker } from '$components/ColorPicker';
 import analyticsEnum from '$lib/analytics/analytics';
 import buildingCatalogue from '$lib/locations/buildingCatalogue';
 import AppStore from '$stores/AppStore';

--- a/apps/antalmanac/src/components/ScheduleManagement/ScheduleManagementContent.tsx
+++ b/apps/antalmanac/src/components/ScheduleManagement/ScheduleManagementContent.tsx
@@ -6,7 +6,7 @@ import { TAB_INDEX, useTabStore } from '$stores/TabStore';
 import Image from 'next/image';
 import { lazy, Suspense } from 'react';
 
-const UCIMap = lazy(() => import('../Map/Map'));
+const UCIMap = lazy(() => import('$components/Map/Map'));
 
 export function ScheduleManagementContent() {
     const activeTab = useTabStore((store) => store.activeTab);

--- a/apps/antalmanac/src/components/buttons/Copy.tsx
+++ b/apps/antalmanac/src/components/buttons/Copy.tsx
@@ -1,4 +1,4 @@
-import CopyScheduleDialog from '$components/dialogs/CopySchedule';
+import { CopyScheduleDialog } from '$components/dialogs/CopySchedule';
 import { useFallbackStore } from '$stores/FallbackStore';
 import { ContentCopy } from '@mui/icons-material';
 import { IconButton, type SxProps, Tooltip } from '@mui/material';

--- a/apps/antalmanac/src/components/buttons/Download.tsx
+++ b/apps/antalmanac/src/components/buttons/Download.tsx
@@ -1,9 +1,8 @@
+import analyticsEnum, { logAnalytics } from '$lib/analytics/analytics';
+import { exportCalendar } from '$lib/download';
 import { Download } from '@mui/icons-material';
 import { IconButton, Tooltip } from '@mui/material';
 import { PostHog, usePostHog } from 'posthog-js/react';
-
-import analyticsEnum, { logAnalytics } from '$lib/analytics/analytics';
-import { exportCalendar } from '$lib/download';
 
 const exportCalendarEvent = (postHog?: PostHog) => {
     return () => {
@@ -15,7 +14,7 @@ const exportCalendarEvent = (postHog?: PostHog) => {
     };
 };
 
-const DownloadButton = () => {
+export function DownloadButton() {
     const postHog = usePostHog();
 
     return (
@@ -25,6 +24,4 @@ const DownloadButton = () => {
             </IconButton>
         </Tooltip>
     );
-};
-
-export default DownloadButton;
+}

--- a/apps/antalmanac/src/components/buttons/Screenshot.tsx
+++ b/apps/antalmanac/src/components/buttons/Screenshot.tsx
@@ -9,7 +9,7 @@ interface ScreenshotButtonProps {
     onScreenshot?: () => void;
 }
 
-const ScreenshotButton = ({ onScreenshot }: ScreenshotButtonProps) => {
+export function ScreenshotButton({ onScreenshot }: ScreenshotButtonProps) {
     const isDark = useThemeStore((store) => store.isDark);
     const postHog = usePostHog();
 
@@ -46,6 +46,4 @@ const ScreenshotButton = ({ onScreenshot }: ScreenshotButtonProps) => {
             </IconButton>
         </Tooltip>
     );
-};
-
-export default ScreenshotButton;
+}

--- a/apps/antalmanac/src/components/dialogs/AddSchedule.tsx
+++ b/apps/antalmanac/src/components/dialogs/AddSchedule.tsx
@@ -7,7 +7,7 @@ import { useState } from 'react';
 /**
  * Dialog with a text field to add a schedule.
  */
-function AddScheduleDialog({ onClose, onKeyDown, ...props }: DialogProps) {
+export function AddScheduleDialog({ onClose, onKeyDown, ...props }: DialogProps) {
     const [name, setName] = useState(() =>
         AppStore.getNextScheduleName(AppStore.getScheduleNames().length, AppStore.getDefaultScheduleName())
     );
@@ -64,5 +64,3 @@ function AddScheduleDialog({ onClose, onKeyDown, ...props }: DialogProps) {
         </Dialog>
     );
 }
-
-export default AddScheduleDialog;

--- a/apps/antalmanac/src/components/dialogs/CopySchedule.tsx
+++ b/apps/antalmanac/src/components/dialogs/CopySchedule.tsx
@@ -17,7 +17,7 @@ interface CopyScheduleDialogProps extends DialogProps {
     index: number;
 }
 
-function CopyScheduleDialog(props: CopyScheduleDialogProps) {
+export function CopyScheduleDialog(props: CopyScheduleDialogProps) {
     const { index } = props;
     const { onClose } = props; // destructured separately for memoization.
     const [name, setName] = useState<string>(`Copy of ${AppStore.getScheduleNames()[index]}`);
@@ -56,5 +56,3 @@ function CopyScheduleDialog(props: CopyScheduleDialogProps) {
         </Dialog>
     );
 }
-
-export default CopyScheduleDialog;

--- a/apps/antalmanac/src/components/dialogs/DeleteSchedule.tsx
+++ b/apps/antalmanac/src/components/dialogs/DeleteSchedule.tsx
@@ -21,7 +21,7 @@ interface ScheduleNameDialogProps extends DialogProps {
 /**
  * Dialog with a prompt to delete the specified schedule.
  */
-function DeleteScheduleDialog(props: ScheduleNameDialogProps) {
+export function DeleteScheduleDialog(props: ScheduleNameDialogProps) {
     /**
      * {@link props.onClose} also needs to be forwarded to the {@link Dialog} component.
      */
@@ -61,5 +61,3 @@ function DeleteScheduleDialog(props: ScheduleNameDialogProps) {
         </Dialog>
     );
 }
-
-export default DeleteScheduleDialog;

--- a/apps/antalmanac/src/components/dialogs/RenameSchedule.tsx
+++ b/apps/antalmanac/src/components/dialogs/RenameSchedule.tsx
@@ -22,7 +22,7 @@ interface ScheduleNameDialogProps extends DialogProps {
 /**
  * Dialog with a form to rename a schedule.
  */
-function RenameScheduleDialog(props: ScheduleNameDialogProps) {
+export function RenameScheduleDialog(props: ScheduleNameDialogProps) {
     /**
      * {@link props.onClose} also needs to be forwarded to the {@link Dialog} component.
      * A custom {@link onKeyDown} handler is provided to handle the Enter and Escape keys.
@@ -86,5 +86,3 @@ function RenameScheduleDialog(props: ScheduleNameDialogProps) {
         </Dialog>
     );
 }
-
-export default RenameScheduleDialog;

--- a/apps/antalmanac/src/lib/TutorialHelpers.tsx
+++ b/apps/antalmanac/src/lib/TutorialHelpers.tsx
@@ -1,8 +1,7 @@
+import { getLocalStorageTourHasRun, getLocalStorageUserId, setLocalStorageTourHasRun } from '$lib/localStorage';
 import { addSampleClasses } from '$lib/tourExampleGeneration';
 import { useTabStore } from '$stores/TabStore';
 import { type StepType } from '@reactour/tour';
-
-import { getLocalStorageTourHasRun, getLocalStorageUserId, setLocalStorageTourHasRun } from './localStorage';
 
 enum TourStepName {
     welcome = 'welcome',

--- a/apps/antalmanac/src/lib/api/trpc.ts
+++ b/apps/antalmanac/src/lib/api/trpc.ts
@@ -1,4 +1,4 @@
-import type { AppRouter } from '$src/backend/routers';
+import type { AppRouter } from '$backend/routers';
 import { createTRPCClient, httpBatchLink } from '@trpc/client';
 import { createTRPCReact } from '@trpc/react-query';
 import superjson from 'superjson';

--- a/apps/antalmanac/src/lib/download.ts
+++ b/apps/antalmanac/src/lib/download.ts
@@ -1,14 +1,13 @@
 import { isCustomEvent, type FinalExam } from '$components/Calendar/types';
 import buildingCatalogue from '$lib/locations/buildingCatalogue';
 import { getDefaultTerm } from '$lib/term';
+import { notNull } from '$lib/utils';
 import AppStore from '$stores/AppStore';
 import { openSnackbar } from '$stores/SnackbarStore';
 import type { AATerm } from '@packages/antalmanac-types';
 import type { HourMinute, Quarter } from '@packages/anteater-api/types';
 import { saveAs } from 'file-saver';
 import { createEvents, type EventAttributes } from 'ics';
-
-import { notNull } from './utils';
 
 const daysOfWeek = ['Su', 'M', 'Tu', 'W', 'Th', 'F', 'Sa'] as const;
 

--- a/apps/antalmanac/src/lib/enrollmentHistory.ts
+++ b/apps/antalmanac/src/lib/enrollmentHistory.ts
@@ -1,7 +1,6 @@
+import { getTermByYearAndQuarter, termData } from '$lib/term';
 import type { AATerm } from '@packages/antalmanac-types';
 import type { EnrollmentHistoryEntry } from '@packages/anteater-api/types';
-
-import { getTermByYearAndQuarter, termData } from './term';
 
 export interface EnrollmentHistory {
     term: AATerm;

--- a/apps/antalmanac/src/routes/Home.tsx
+++ b/apps/antalmanac/src/routes/Home.tsx
@@ -3,7 +3,7 @@ import { ScheduleCalendar } from '$components/Calendar/CalendarRoot';
 import { Header } from '$components/Header/Header';
 import { KeyboardShortcutsModal } from '$components/KeyboardShortcutsModal/KeyboardShortcutsModal';
 import { NotificationSnackbar } from '$components/NotificationSnackbar';
-import PatchNotes from '$components/PatchNotes';
+import { PatchNotes } from '$components/PatchNotes';
 import { ReviewPrompt } from '$components/ReviewPrompt/ReviewPrompt';
 import { ScheduleManagement } from '$components/ScheduleManagement/ScheduleManagement';
 import { TutorialInitializer } from '$components/TutorialInitializer';

--- a/apps/antalmanac/src/stores/Schedules.ts
+++ b/apps/antalmanac/src/stores/Schedules.ts
@@ -1,6 +1,8 @@
 import { trpc } from '$lib/api/trpc';
 import { getDefaultTerm, getTermByShortName } from '$lib/term';
 import { moveArrayElements } from '$lib/utils';
+import { calendarizeCourseEvents, calendarizeCustomEvents, calendarizeFinals } from '$stores/calendarizeHelpers';
+import { useHiddenCoursesStore } from '$stores/HiddenCoursesStore';
 import {
     getColorForNewSection,
     groupCourseSections,
@@ -20,9 +22,6 @@ import type {
     ShortCourseSchedule,
 } from '@packages/antalmanac-types';
 import { createId } from '@paralleldrive/cuid2';
-
-import { calendarizeCourseEvents, calendarizeCustomEvents, calendarizeFinals } from './calendarizeHelpers';
-import { useHiddenCoursesStore } from './HiddenCoursesStore';
 
 /**
  * Manages state of schedules. Only one instance is really needed for the app.

--- a/apps/antalmanac/tests/authUtils.test.ts
+++ b/apps/antalmanac/tests/authUtils.test.ts
@@ -1,6 +1,5 @@
+import { getSafeAuthRedirectPath } from '$lib/auth/authUtils';
 import { describe, expect, test } from 'vitest';
-
-import { getSafeAuthRedirectPath } from '../src/lib/auth/authUtils';
 
 const VALID_URL = '/importRoadmap=1234&term=2026+Spring';
 const ALLOWED_ORIGIN = 'https://www.antalmanac.com';

--- a/apps/antalmanac/tests/patch-notes.test.tsx
+++ b/apps/antalmanac/tests/patch-notes.test.tsx
@@ -1,4 +1,4 @@
-import PatchNotes, { closeButtonTestId, dialogTestId, backdropTestId } from '$components/PatchNotes';
+import { PatchNotes, closeButtonTestId, dialogTestId, backdropTestId } from '$components/PatchNotes';
 import {
     getLocalStoragePatchNotesKey,
     setLocalStoragePatchNotesKey,

--- a/apps/antalmanac/tests/schedule.test.tsx
+++ b/apps/antalmanac/tests/schedule.test.tsx
@@ -1,7 +1,7 @@
-import { describe, test, expect } from 'vitest';
-import { render } from '@testing-library/react';
+import { RenameScheduleDialog } from '$components/dialogs/RenameSchedule';
 import { Schedules } from '$stores/Schedules';
-import RenameScheduleDialog from '$components/dialogs/RenameSchedule';
+import { render } from '@testing-library/react';
+import { describe, test, expect } from 'vitest';
 
 describe('schedule logic', () => {
     const scheduleStore = new Schedules();

--- a/apps/antalmanac/tsconfig.json
+++ b/apps/antalmanac/tsconfig.json
@@ -12,6 +12,7 @@
         "paths": {
             "$actions/*": ["src/actions/*"],
             "$api/*": ["src/api/*"],
+            "$backend/*": ["src/backend/*"],
             "$components/*": ["src/components/*"],
             "$generated/*": ["src/generated/*"],
             "$lib/*": ["src/lib/*"],

--- a/apps/antalmanac/vite.config.ts
+++ b/apps/antalmanac/vite.config.ts
@@ -8,7 +8,6 @@ export default defineConfig({
     plugins: [react(), svgr()],
     resolve: {
         alias: {
-            $assets: resolve(__dirname, './src/assets'),
             $actions: resolve(__dirname, './src/actions'),
             $api: resolve(__dirname, './src/api'),
             $backend: resolve(__dirname, './src/backend'),

--- a/apps/antalmanac/vite.config.ts
+++ b/apps/antalmanac/vite.config.ts
@@ -1,6 +1,7 @@
 import { resolve } from 'node:path';
-import { defineConfig } from 'vite';
+
 import react from '@vitejs/plugin-react';
+import { defineConfig } from 'vite';
 import svgr from 'vite-plugin-svgr';
 
 export default defineConfig({
@@ -10,6 +11,7 @@ export default defineConfig({
             $assets: resolve(__dirname, './src/assets'),
             $actions: resolve(__dirname, './src/actions'),
             $api: resolve(__dirname, './src/api'),
+            $backend: resolve(__dirname, './src/backend'),
             $components: resolve(__dirname, './src/components'),
             $generated: resolve(__dirname, './src/generated'),
             $lib: resolve(__dirname, './src/lib'),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Cleanup pass for import and export conventions in `apps/antalmanac`. No behavior changes.

### Path aliases

- Add `$backend/*` → `src/backend/*` in `tsconfig.json` and `vite.config.ts`
- Replace cross-module relative imports with configured aliases:
  - `$stores`, `$lib`, `$components`, `$src` in frontend, tests, and scripts
  - `$backend` across tRPC routers, RDS helpers, and API routes
- Remove unused `$assets` vite alias (`src/assets` no longer exists)

### Named component exports

Convert default exports to named exports (matching existing components like `SignInDialog` and `ClearScheduleButton`):

- Schedule dialogs: `RenameScheduleDialog`, `DeleteScheduleDialog`, `CopyScheduleDialog`, `AddScheduleDialog`
- Toolbar: `DownloadButton`, `ScreenshotButton`
- UI: `PatchNotes`, `ColorPicker`

Update consumers and tests to use `{ NamedImport }`.

### Asset URL cleanup

- Remove the legacy `/assets/:path*` → `/logos/:path*` redirect from `next.config.ts` (all in-repo references already use `/logos/`)

## Test Plan

- [x] `pnpm format`
- [x] `pnpm lint`
- [x] `pnpm vitest run apps/antalmanac/tests/authUtils.test.ts apps/antalmanac/tests/schedule.test.tsx apps/antalmanac/tests/patch-notes.test.tsx`
- [x] `pnpm --filter antalmanac build`
- [ ] CI green

## Issues

Closes #
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1f44341d-d40e-4a21-a892-86c472c1050f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1f44341d-d40e-4a21-a892-86c472c1050f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

