### PR TITLE
perf: remove ua-parser-js from fuzzy search auto-focus

### DIFF
--- a/apps/antalmanac/package.json
+++ b/apps/antalmanac/package.json
@@ -70,7 +70,6 @@
         "recharts": "^2.4.2",
         "schema-dts": "^2.0.0",
         "superjson": "^1.12.3",
-        "ua-parser-js": "^1.0.37",
         "zod": "3.24.3",
         "zustand": "^4.3.2"
     },
@@ -87,7 +86,6 @@
         "@types/react-color": "^3.0.6",
         "@types/react-dom": "19.2.3",
         "@types/react-lazyload": "^3.2.0",
-        "@types/ua-parser-js": "^0.7.39",
         "@vitejs/plugin-react": "^4.0.4",
         "typescript": "^5.9.3",
         "vite": "^4.4.9",

--- a/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/QuickSearch/FuzzySearch.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/SearchForm/QuickSearch/FuzzySearch.tsx
@@ -15,7 +15,6 @@ import { type AutocompleteInputChangeReason, type AutocompleteRenderGroupParams,
 import type { AATerm, SearchResult } from '@packages/antalmanac-types';
 import { usePostHog } from 'posthog-js/react';
 import { useCallback, useEffect, useRef, useState } from 'react';
-import UAParser from 'ua-parser-js';
 
 const SEARCH_TIMEOUT_MS = 150;
 
@@ -43,14 +42,7 @@ const romanArr = ['I', 'II', 'III', 'IV', 'V', 'VI', 'VII', 'VIII'];
 
 const MIN_QUERY_LENGTH = 2;
 
-const isMobile = () => {
-    const parser = new UAParser();
-    return parser.getDevice().type === 'mobile' || parser.getDevice().type === 'tablet' || isIpad();
-};
-
-const isIpad = () => {
-    return navigator.userAgent.includes('Mac') && 'ontouchend' in document;
-};
+const shouldAutoFocusSearch = () => globalThis.matchMedia?.('(hover: hover) and (pointer: fine)')?.matches ?? false;
 
 interface SearchOption {
     key: string;
@@ -345,7 +337,7 @@ export function FuzzySearch() {
                 clearOnBlur: false,
             }}
             textFieldProps={{
-                autoFocus: !isMobile(),
+                autoFocus: shouldAutoFocusSearch(),
                 placeholder: 'Search for courses, departments, GEs...',
                 fullWidth: true,
                 onFocus: onFocus,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -261,9 +261,6 @@ importers:
       superjson:
         specifier: ^1.12.3
         version: 1.13.3
-      ua-parser-js:
-        specifier: ^1.0.37
-        version: 1.0.39
       zod:
         specifier: 3.24.3
         version: 3.24.3
@@ -307,9 +304,6 @@ importers:
       '@types/react-lazyload':
         specifier: ^3.2.0
         version: 3.2.3
-      '@types/ua-parser-js':
-        specifier: ^0.7.39
-        version: 0.7.39
       '@vitejs/plugin-react':
         specifier: ^4.0.4
         version: 4.3.3(vite@4.5.5(@types/node@22.19.17)(stylus@0.51.1)(terser@5.46.2))
@@ -3256,9 +3250,6 @@ packages:
   '@types/trusted-types@2.0.7':
     resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
 
-  '@types/ua-parser-js@0.7.39':
-    resolution: {integrity: sha512-P/oDfpofrdtF5xw433SPALpdSchtJmY7nsJItf8h3KXqOslkbySh8zq4dSWXH2oTjRvJ5PczVEoCZPow6GicLg==}
-
   '@types/warning@3.0.0':
     resolution: {integrity: sha512-t/Tvs5qR47OLOr+4E9ckN8AmP2Tf16gWq+/qA4iUGS/OOyHVO8wv2vjJuX8SNOUTJyWb+2t7wJm6cXILFnOROA==}
 
@@ -6188,10 +6179,6 @@ packages:
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
-    hasBin: true
-
-  ua-parser-js@1.0.39:
-    resolution: {integrity: sha512-k24RCVWlEcjkdOxYmVJgeD/0a1TiSpqLg+ZalVGV9lsnr4yqu0w7tX/x2xX6G4zpkgQnRf89lxuZ1wsbjXM8lw==}
     hasBin: true
 
   ufo@1.5.4:
@@ -9579,8 +9566,6 @@ snapshots:
 
   '@types/trusted-types@2.0.7': {}
 
-  '@types/ua-parser-js@0.7.39': {}
-
   '@types/warning@3.0.0': {}
 
   '@vitejs/plugin-react@4.3.3(vite@4.5.5(@types/node@22.19.17)(stylus@0.51.1)(terser@5.46.2))':
@@ -12710,8 +12695,6 @@ snapshots:
       possible-typed-array-names: 1.0.0
 
   typescript@5.9.3: {}
-
-  ua-parser-js@1.0.39: {}
 
   ufo@1.5.4: {}
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Removes `ua-parser-js` and `@types/ua-parser-js`. The package was only used in `FuzzySearch` to decide whether the quick-search input should `autoFocus` on load.

Replaces UA device sniffing with interaction-capability detection:

```ts
globalThis.matchMedia?.('(hover: hover) and (pointer: fine)')?.matches ?? false
```

Touch-primary devices (`pointer: coarse`, `hover: none`) skip auto-focus so the virtual keyboard does not open on page load. Desktop users with a fine pointer still get auto-focus.

Estimated savings: ~9–13 KiB gzip off the initial bundle (search tab is the default view and eagerly loaded).

## Test Plan

- [ ] Desktop: quick-search input auto-focuses on load
- [ ] Mobile (or DevTools device emulation): quick-search does **not** auto-focus; keyboard stays closed
- [ ] Fuzzy search still works (type, select result, submit)
- [ ] No console errors on load

## Issues

Closes #
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4b39a145-24c4-47f8-b2f9-9921ffd1bbb7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4b39a145-24c4-47f8-b2f9-9921ffd1bbb7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

