### PR TITLE
chore: named exports for section table and providers

### DIFF
--- a/apps/antalmanac/src/app/Theme.tsx
+++ b/apps/antalmanac/src/app/Theme.tsx
@@ -118,7 +118,7 @@ declare module '@mui/material/styles' {
 /**
  * sets and provides the MUI theme for the app
  */
-export default function AppThemeProvider(props: Props) {
+export function AppThemeProvider(props: Props) {
     const [isDark, syncSystemTheme] = useThemeStore(useShallow((store) => [store.isDark, store.syncSystemTheme]));
 
     useEffect(() => {

--- a/apps/antalmanac/src/app/providers.tsx
+++ b/apps/antalmanac/src/app/providers.tsx
@@ -1,9 +1,9 @@
 'use client';
 
-import AppPostHogProvider from '$providers/AppPostHogProvider';
-import AppQueryProvider from '$providers/AppQueryProvider';
-import AppTourProvider from '$providers/AppTourProvider';
-import AppThemeProvider from '$src/app/Theme';
+import { AppPostHogProvider } from '$providers/AppPostHogProvider';
+import { AppQueryProvider } from '$providers/AppQueryProvider';
+import { AppTourProvider } from '$providers/AppTourProvider';
+import { AppThemeProvider } from '$src/app/Theme';
 import { AppRouterCacheProvider } from '@mui/material-nextjs/v15-appRouter';
 
 export function Providers({ children }: { children: React.ReactNode }) {

--- a/apps/antalmanac/src/components/RightPane/AddedCourses/AddedCoursesList.tsx
+++ b/apps/antalmanac/src/components/RightPane/AddedCourses/AddedCoursesList.tsx
@@ -1,7 +1,7 @@
 import { SortableList } from '$components/drag-and-drop/SortableList';
 import { EmptyState } from '$components/EmptyState';
 import { AddedCoursesLoadingSkeleton } from '$components/RightPane/AddedCourses/AddedCoursesLoadingSkeleton';
-import SectionTable from '$components/RightPane/SectionTable/SectionTable';
+import { SectionTable } from '$components/RightPane/SectionTable/SectionTable';
 import analyticsEnum from '$lib/analytics/analytics';
 import { getMissingSections } from '$lib/courseAlerts';
 import { useScheduleComponentsToggleStore } from '$stores/ScheduleComponentsToggleStore';

--- a/apps/antalmanac/src/components/RightPane/AddedCourses/AddedCoursesLoadingSkeleton.tsx
+++ b/apps/antalmanac/src/components/RightPane/AddedCourses/AddedCoursesLoadingSkeleton.tsx
@@ -1,5 +1,5 @@
 import { CustomEventDetailView } from '$components/RightPane/AddedCourses/CustomEventDetailView';
-import SectionTable from '$components/RightPane/SectionTable/SectionTable';
+import { SectionTable } from '$components/RightPane/SectionTable/SectionTable';
 import analyticsEnum from '$lib/analytics/analytics';
 import { getLocalStorageAddedCoursesSkeletonBlueprint } from '$lib/localStorage';
 import AppStore from '$stores/AppStore';

--- a/apps/antalmanac/src/components/RightPane/CoursePane/CourseRenderPane/CourseList/CourseListItem.tsx
+++ b/apps/antalmanac/src/components/RightPane/CoursePane/CourseRenderPane/CourseList/CourseListItem.tsx
@@ -5,8 +5,8 @@ import {
     isSchoolEntry,
 } from '$components/RightPane/CoursePane/CourseRenderPane/CourseList/helpers';
 import type { CourseSearchParams } from '$components/RightPane/CoursePane/SearchParams/types';
-import GeDataFetchProvider from '$components/RightPane/SectionTable/GEDataFetchProvider';
-import SectionTable from '$components/RightPane/SectionTable/SectionTable';
+import { GeDataFetchProvider } from '$components/RightPane/SectionTable/GEDataFetchProvider';
+import { SectionTable } from '$components/RightPane/SectionTable/SectionTable';
 import analyticsEnum from '$lib/analytics/analytics';
 
 interface CourseListItemProps {

--- a/apps/antalmanac/src/components/RightPane/SectionTable/CourseInfo/CourseInfoBarPopover.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/CourseInfo/CourseInfoBarPopover.tsx
@@ -1,4 +1,4 @@
-import PrereqTree from '$components/RightPane/SectionTable/CourseInfo/PrereqTree';
+import { PrereqTree } from '$components/RightPane/SectionTable/CourseInfo/PrereqTree';
 import analyticsEnum, { type AnalyticsCategory, logAnalytics } from '$lib/analytics/analytics';
 import { getRenamedCoursesLabel } from '$lib/renames/utils';
 import { Box, Card, CardContent, CardHeader, Divider, Skeleton, Typography } from '@mui/material';

--- a/apps/antalmanac/src/components/RightPane/SectionTable/CourseInfo/PrereqTree.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/CourseInfo/PrereqTree.tsx
@@ -91,7 +91,7 @@ interface PrereqTreeProps {
     course: Course;
 }
 
-const PrereqTree: FC<PrereqTreeProps> = ({ course }) => {
+export const PrereqTree: FC<PrereqTreeProps> = ({ course }) => {
     const { id, department, courseNumber, prerequisiteTree, dependencies } = course;
     const hasPrereqs = Object.keys(prerequisiteTree).length > 0;
     const hasDependencies = dependencies.length > 0;
@@ -176,5 +176,3 @@ const PrereqTree: FC<PrereqTreeProps> = ({ course }) => {
         </div>
     );
 };
-
-export default PrereqTree;

--- a/apps/antalmanac/src/components/RightPane/SectionTable/GEDataFetchProvider.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/GEDataFetchProvider.tsx
@@ -1,6 +1,6 @@
 import { useCourseSearchParam } from '$components/RightPane/CoursePane/SearchParams/hooks';
 import { advancedSearchParsers } from '$components/RightPane/CoursePane/SearchParams/parsers';
-import SectionTable, { type SectionTableProps } from '$components/RightPane/SectionTable/SectionTable';
+import { SectionTable, type SectionTableProps } from '$components/RightPane/SectionTable/SectionTable';
 import { trpcReact } from '$lib/api/trpc';
 import AppStore from '$stores/AppStore';
 import type { AACourseWithTerm } from '@packages/antalmanac-types';
@@ -13,7 +13,7 @@ import { useMemo } from 'react';
  * This is because all the non-lecture sections don't have the GE specified so the initial search that included the
  * GE criteria will miss them.
  */
-const GeDataFetchProvider = (props: SectionTableProps) => {
+export function GeDataFetchProvider(props: SectionTableProps) {
     const [term] = useCourseSearchParam('term');
     const [advanced] = useQueryStates(advancedSearchParsers);
 
@@ -67,6 +67,4 @@ const GeDataFetchProvider = (props: SectionTableProps) => {
     }, [data, props.course, term]);
 
     return <SectionTable {...props} course={course} />;
-};
-
-export default GeDataFetchProvider;
+}

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTable.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTable.tsx
@@ -75,7 +75,7 @@ export interface SectionTableProps {
     missingSections?: string[];
 }
 
-function SectionTable({
+export function SectionTable({
     course,
     allowHighlight,
     scheduleNames,
@@ -264,5 +264,3 @@ function SectionTable({
         </Box>
     );
 }
-
-export default SectionTable;

--- a/apps/antalmanac/src/providers/AppPostHogProvider.tsx
+++ b/apps/antalmanac/src/providers/AppPostHogProvider.tsx
@@ -20,7 +20,7 @@ interface Props {
     children?: React.ReactNode;
 }
 
-export default function AppPostHogProvider(props: Props) {
+export function AppPostHogProvider(props: Props) {
     if (env.NEXT_PUBLIC_PUBLIC_POSTHOG_KEY) {
         return <PostHogProvider client={postHog}>{props.children}</PostHogProvider>;
     }

--- a/apps/antalmanac/src/providers/AppQueryProvider.tsx
+++ b/apps/antalmanac/src/providers/AppQueryProvider.tsx
@@ -2,7 +2,7 @@ import { trpcConfig, trpcReact } from '$lib/api/trpc';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { useState } from 'react';
 
-export default function AppQueryProvider({ children }: { children?: React.ReactNode }) {
+export function AppQueryProvider({ children }: { children?: React.ReactNode }) {
     const [queryClient] = useState(
         () =>
             new QueryClient({

--- a/apps/antalmanac/src/providers/AppTourProvider.tsx
+++ b/apps/antalmanac/src/providers/AppTourProvider.tsx
@@ -5,7 +5,7 @@ interface Props {
     children?: React.ReactNode;
 }
 
-export default function AppTourProvider({ children }: Props) {
+export function AppTourProvider({ children }: Props) {
     return (
         <TourProvider
             steps={[] /** Will be populated by Tutorial component */}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Converts remaining section table and provider components from default exports to named exports. No behavior changes.

### Section table

| Component | Export |
|-----------|--------|
| `SectionTable` | `export function` |
| `GeDataFetchProvider` | `export function` |
| `PrereqTree` | `export const` |

Consumers updated: `GEDataFetchProvider.tsx`, `CourseListItem.tsx`, `AddedCoursesList.tsx`, `AddedCoursesLoadingSkeleton.tsx`, `CourseInfoBarPopover.tsx`.

### Providers

| Component | Export |
|-----------|--------|
| `AppPostHogProvider` | `export function` (existing `postHog` named export unchanged) |
| `AppQueryProvider` | `export function` |
| `AppTourProvider` | `export function` |
| `AppThemeProvider` | `export function` |

Consumer updated: `app/providers.tsx`.

## Test Plan

- [x] `pnpm format`
- [x] `pnpm lint`
- [x] `pnpm vitest run apps/antalmanac/tests/schedule.test.tsx apps/antalmanac/tests/patch-notes.test.tsx` — 10/10 pass
- [x] `pnpm --filter antalmanac build`
- [ ] CI green

## Issues

Closes #
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1f44341d-d40e-4a21-a892-86c472c1050f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1f44341d-d40e-4a21-a892-86c472c1050f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

