### PR TITLE
chore: named exports for app shell, map, and charts

### DIFF
--- a/apps/antalmanac/src/App.tsx
+++ b/apps/antalmanac/src/App.tsx
@@ -1,9 +1,9 @@
 import './App.css';
 import { undoDelete, redoDelete } from '$actions/AppStoreActions';
 import { AutoSignIn } from '$components/AutoSignIn';
-import PosthogPageviewTracker from '$lib/analytics/PostHogPageviewTracker';
+import { PosthogPageviewTracker } from '$lib/analytics/PostHogPageviewTracker';
 import { ErrorPage } from '$routes/ErrorPage';
-import Home from '$routes/Home';
+import { Home } from '$routes/Home';
 import { OutagePage } from '$routes/OutagePage';
 import { NuqsAdapter } from 'nuqs/adapters/react-router/v6';
 import { useEffect } from 'react';
@@ -86,7 +86,7 @@ const ROUTER = OUTAGE ? OUTAGE_ROUTER : BROWSER_ROUTER;
 /**
  * Renders the single page application.
  */
-export default function App() {
+export function App() {
     useEffect(() => {
         document.addEventListener('keydown', undoDelete, false);
         document.addEventListener('keydown', redoDelete, false);

--- a/apps/antalmanac/src/app/[[...slug]]/client.tsx
+++ b/apps/antalmanac/src/app/[[...slug]]/client.tsx
@@ -2,7 +2,7 @@
 
 import dynamic from 'next/dynamic';
 
-const App = dynamic(() => import('$src/App'), { ssr: false });
+const App = dynamic(() => import('$src/App').then((m) => ({ default: m.App })), { ssr: false });
 
 export function ClientOnly() {
     return <App />;

--- a/apps/antalmanac/src/components/Map/Map.tsx
+++ b/apps/antalmanac/src/components/Map/Map.tsx
@@ -10,9 +10,9 @@ import { Fragment, useEffect, useRef, useCallback, useState, useMemo } from 'rea
 import { MapContainer, TileLayer } from 'react-leaflet';
 import { useSearchParams, useNavigate } from 'react-router-dom';
 
-import LocationMarker from './Marker';
+import { LocationMarker } from './Marker';
 
-const Routes = dynamic(() => import('./Routes'), { ssr: false });
+const Routes = dynamic(() => import('./Routes').then((m) => ({ default: m.Routes })), { ssr: false });
 
 import {
     isCourseEvent,
@@ -163,7 +163,7 @@ export function getCustomEventPerBuilding(customEvents: CustomEvent[] = AppStore
 /**
  * Map of all course locations on UCI campus.
  */
-export default function CourseMap() {
+export function CourseMap() {
     const navigate = useNavigate();
     const map = useRef<Map | null>(null);
     const markerRef = useRef<Marker | null>(null);

--- a/apps/antalmanac/src/components/Map/Marker.tsx
+++ b/apps/antalmanac/src/components/Map/Marker.tsx
@@ -1,11 +1,10 @@
+import analyticsEnum, { logAnalytics } from '$lib/analytics/analytics';
 import { DirectionsWalk as DirectionsWalkIcon, Info } from '@mui/icons-material';
 import { Box, Button, IconButton, Typography } from '@mui/material';
 import { type Marker, divIcon } from 'leaflet';
 import { usePostHog } from 'posthog-js/react';
 import { forwardRef, type Ref } from 'react';
 import { Marker as ReactLeafletMarker, Popup } from 'react-leaflet';
-
-import analyticsEnum, { logAnalytics } from '$lib/analytics/analytics';
 
 const GOOGLE_MAPS_URL = 'https://www.google.com/maps/dir/?api=1&travelmode=walking&destination=';
 const IMAGE_CMS_URL = 'https://cms.concept3d.com/map/lib/image-cache/i.php?mapId=463&image=';
@@ -73,7 +72,7 @@ interface Props {
 /**
  * Custom map marker + popup with course info.
  */
-const LocationMarker = forwardRef(
+export const LocationMarker = forwardRef(
     ({ lat, lng, color, image, location, acronym, stackIndex, label, children }: Props, ref?: Ref<Marker>) => {
         const postHog = usePostHog();
 
@@ -167,5 +166,3 @@ const LocationMarker = forwardRef(
 );
 
 LocationMarker.displayName = 'LocationMarker';
-
-export default LocationMarker;

--- a/apps/antalmanac/src/components/Map/Routes.tsx
+++ b/apps/antalmanac/src/components/Map/Routes.tsx
@@ -1,11 +1,10 @@
+import { MAPBOX_PROXY_DIRECTIONS_ENDPOINT } from '$lib/api/endpoints';
 // eslint-disable-next-line import/default
 import L from 'leaflet';
-import type { LatLngTuple } from 'leaflet';
 import 'leaflet-routing-machine';
+import type { LatLngTuple } from 'leaflet';
 import { useEffect } from 'react';
 import { useMap } from 'react-leaflet';
-
-import { MAPBOX_PROXY_DIRECTIONS_ENDPOINT } from '$lib/api/endpoints';
 
 interface ClassRoutesProps {
     /**
@@ -30,7 +29,7 @@ const dontCreateMarker = () => false;
 /**
  * Given waypoints of a route and a color for the route, draw a route to the map.
  */
-function Routes(props: ClassRoutesProps) {
+export function Routes(props: ClassRoutesProps) {
     const map = useMap();
 
     useEffect(() => {
@@ -138,5 +137,3 @@ function Routes(props: ClassRoutesProps) {
 
     return null;
 }
-
-export default Routes;

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTablePopover/EnrollmentHistoryPopover.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTablePopover/EnrollmentHistoryPopover.tsx
@@ -11,10 +11,13 @@ import type { WebsocSectionType } from '@packages/anteater-api/types';
 import dynamic from 'next/dynamic';
 import { useCallback, useMemo, useState } from 'react';
 
-const EnrollmentHistoryPopoverChart = dynamic(() => import('./EnrollmentHistoryPopoverChart'), {
-    ssr: false,
-    loading: () => <Skeleton variant="rectangular" animation="wave" height="100%" width="100%" />,
-});
+const EnrollmentHistoryPopoverChart = dynamic(
+    () => import('./EnrollmentHistoryPopoverChart').then((m) => ({ default: m.EnrollmentHistoryPopoverChart })),
+    {
+        ssr: false,
+        loading: () => <Skeleton variant="rectangular" animation="wave" height="100%" width="100%" />,
+    }
+);
 
 interface EnrollmentHistoryPopoverProps {
     sectionType: WebsocSectionType;

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTablePopover/EnrollmentHistoryPopoverChart.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTablePopover/EnrollmentHistoryPopoverChart.tsx
@@ -15,7 +15,7 @@ interface EnrollmentHistoryPopoverChartProps {
     days: EnrollmentHistoryDay[];
 }
 
-export default function EnrollmentHistoryPopoverChart({ days }: EnrollmentHistoryPopoverChartProps) {
+export function EnrollmentHistoryPopoverChart({ days }: EnrollmentHistoryPopoverChartProps) {
     const theme = useTheme();
     const chartColors = theme.palette.enrollmentStatus;
 

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTablePopover/GradesPopover.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTablePopover/GradesPopover.tsx
@@ -15,10 +15,13 @@ import type { AggregateGrades } from '@packages/anteater-api/types';
 import dynamic from 'next/dynamic';
 import { useMemo, useState } from 'react';
 
-const GradesPopoverChart = dynamic(() => import('./GradesPopoverChart'), {
-    ssr: false,
-    loading: () => <Skeleton variant="rectangular" animation="wave" height="100%" width="100%" />,
-});
+const GradesPopoverChart = dynamic(
+    () => import('./GradesPopoverChart').then((m) => ({ default: m.GradesPopoverChart })),
+    {
+        ssr: false,
+        loading: () => <Skeleton variant="rectangular" animation="wave" height="100%" width="100%" />,
+    }
+);
 
 type GradeView = 'instructor' | 'overall';
 

--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTablePopover/GradesPopoverChart.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTablePopover/GradesPopoverChart.tsx
@@ -8,7 +8,7 @@ interface GradesPopoverChartProps {
     }[];
 }
 
-export default function GradesPopoverChart({ grades }: GradesPopoverChartProps) {
+export function GradesPopoverChart({ grades }: GradesPopoverChartProps) {
     const theme = useTheme();
     const secondaryColor = theme.palette.secondary.main;
 

--- a/apps/antalmanac/src/components/ScheduleManagement/ScheduleManagementContent.tsx
+++ b/apps/antalmanac/src/components/ScheduleManagement/ScheduleManagementContent.tsx
@@ -6,7 +6,7 @@ import { TAB_INDEX, useTabStore } from '$stores/TabStore';
 import Image from 'next/image';
 import { lazy, Suspense } from 'react';
 
-const UCIMap = lazy(() => import('$components/Map/Map'));
+const UCIMap = lazy(() => import('$components/Map/Map').then((m) => ({ default: m.CourseMap })));
 
 export function ScheduleManagementContent() {
     const activeTab = useTabStore((store) => store.activeTab);

--- a/apps/antalmanac/src/lib/analytics/PostHogPageviewTracker.tsx
+++ b/apps/antalmanac/src/lib/analytics/PostHogPageviewTracker.tsx
@@ -2,7 +2,7 @@ import { postHog } from '$providers/AppPostHogProvider';
 import { useEffect } from 'react';
 import { useLocation } from 'react-router-dom';
 
-export default function PosthogPageviewTracker() {
+export function PosthogPageviewTracker() {
     const location = useLocation();
 
     useEffect(() => {

--- a/apps/antalmanac/src/routes/Home.tsx
+++ b/apps/antalmanac/src/routes/Home.tsx
@@ -76,7 +76,7 @@ function DesktopHome() {
     );
 }
 
-export default function Home() {
+export function Home() {
     const isMobile = useIsMobile();
     const { open: shortcutsOpen, closeModal: closeShortcutsModal } = useKeyboardShortcutsModal();
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Converts the remaining migratable React components from default exports to named exports. Lazy and dynamic import loaders are updated to resolve named exports via `.then((m) => ({ default: m.Component }))`.

### App shell

| Component | Export |
|-----------|--------|
| `App` | `export function` |
| `Home` | `export function` |
| `PosthogPageviewTracker` | `export function` |

Updated: `App.tsx`, `client.tsx` (`next/dynamic` loader).

### Map cluster

| Component | Export |
|-----------|--------|
| `CourseMap` | `export function` |
| `LocationMarker` | `export const` (forwardRef) |
| `Routes` | `export function` |

Updated: `Map.tsx`, `ScheduleManagementContent.tsx` (`React.lazy` loader).

### Chart lazy chunks

| Component | Export |
|-----------|--------|
| `GradesPopoverChart` | `export function` |
| `EnrollmentHistoryPopoverChart` | `export function` |

Updated: `GradesPopover.tsx`, `EnrollmentHistoryPopover.tsx` (`next/dynamic` loaders).

## Test Plan

- [x] `pnpm format`
- [x] `pnpm lint`
- [x] `pnpm --filter antalmanac build`
- [ ] CI green

## Issues

Closes #
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1f44341d-d40e-4a21-a892-86c472c1050f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1f44341d-d40e-4a21-a892-86c472c1050f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

