### PR TITLE
fix: keep notification button in middle of action cells

### DIFF
--- a/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/action-cell/ActionCell.tsx
+++ b/apps/antalmanac/src/components/RightPane/SectionTable/SectionTableBody/SectionTableBodyCells/action-cell/ActionCell.tsx
@@ -47,7 +47,15 @@ export const ActionCell = memo(({ section, course, scheduleConflict, addedCourse
                     <AddButton section={section} course={course} scheduleConflict={scheduleConflict} />
                 )}
 
-                {addedCourse && (
+                {initialized ? (
+                    <NotificationsMenu section={section} course={course} />
+                ) : (
+                    <IconButton disabled size="small" sx={{ p: 0.5 }}>
+                        <CircularProgress size={15} />
+                    </IconButton>
+                )}
+
+                {addedCourse ? (
                     <Tooltip
                         title={
                             classVisibility === VisibilityState.Visible
@@ -68,17 +76,9 @@ export const ActionCell = memo(({ section, course, scheduleConflict, addedCourse
                             )}
                         </IconButton>
                     </Tooltip>
-                )}
-
-                {initialized ? (
-                    <NotificationsMenu section={section} course={course} />
                 ) : (
-                    <IconButton disabled size="small" sx={{ p: 0.5 }}>
-                        <CircularProgress size={15} />
-                    </IconButton>
+                    <SectionActionMenu section={section} course={course} scheduleNames={scheduleNames} />
                 )}
-
-                {!addedCourse && <SectionActionMenu section={section} course={course} scheduleNames={scheduleNames} />}
             </Box>
         </TableBodyCellContainer>
     );


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Action cell button order was inconsistent between added and non-added section states. The notification button is now always in the middle position.

| State | Before | After |
|-------|--------|-------|
| Not added | Add → Notif → Menu | Add → Notif → Menu (unchanged) |
| Added | Delete → Visibility → Notif | Delete → Notif → Visibility |

## Changes

- Reordered `ActionCell` so `NotificationsMenu` renders between the primary action (Add/Delete) and the tertiary action (SectionActionMenu / visibility toggle).

## Test plan

- [ ] Open a course in search — verify action cell order is Add | Notif | Menu
- [ ] Add a section — verify action cell order is Delete | Notif | Visibility
- [ ] Confirm notification menu still opens and toggles work in both states
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-efaa6ca8-22e7-4c7c-85eb-106d18ae1e8f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-efaa6ca8-22e7-4c7c-85eb-106d18ae1e8f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

