### PR TITLE
docs: Cursor Cloud development environment setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,38 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+AntAlmanac is a **pnpm monorepo** (Node.js ≥ 22, pnpm 10). The primary product is the Next.js app in `apps/antalmanac`.
+
+### Services
+
+| Service | Command | Notes |
+|---------|---------|-------|
+| PostgreSQL | `sudo docker compose up -d --build` | Port 5432; credentials in `docker-compose.yml` |
+| Web app | `pnpm dev` | http://localhost:3000 |
+
+Docker must be running (`sudo service docker start` if needed). The VM uses `fuse-overlayfs` as the Docker storage driver.
+
+### First-time local setup (after `pnpm install`)
+
+1. Copy env templates: `apps/antalmanac/.env.example` → `.env`, `packages/db/.env.example` → `.env`
+2. Generate `BETTER_AUTH_SECRET` (any random string) in `apps/antalmanac/.env`
+3. Set a valid `ANTEATER_API_KEY` in `apps/antalmanac/.env` (required for `get-data` and live WebSoc)
+4. Start Postgres, then apply schema:
+   - **Fresh DB:** `cd packages/db && pnpm drizzle-kit push --force` — `pnpm db:migrate` fails on empty databases because Drizzle runs all migrations in one transaction and PostgreSQL rejects enum values used before commit (migration `0020_better_auth.sql`)
+   - **Existing DB:** `pnpm db:migrate` works when migrations were applied incrementally
+5. Fetch generated data: `cd apps/antalmanac && pnpm get-data` (writes `src/generated/termData.json`, `searchData.json`, and `src/generated/terms/*.json`; gitignored except `departments.json` / `deployed_terms.json`)
+
+### Standard commands (see root `package.json` and `README.md`)
+
+- **Lint:** `pnpm lint`
+- **Test:** `pnpm test run` (CI runs `pnpm --filter antalmanac fetch-term-data` first; full `get-data` is needed for dev server)
+- **Dev:** `pnpm dev`
+- **DB studio:** `pnpm db:studio`
+
+### Gotchas
+
+- `ANTEATER_API_KEY` is mandatory for runtime WebSoc/course data; stub generated JSON only exercises search autocomplete.
+- Auth (Google/Apple sign-in) uses external ICSSC OIDC (`OIDC_*` vars in `.env.example`); optional for anonymous browsing.
+- `MAPBOX_ACCESS_TOKEN` is optional; map routes 500 without it.
+- Husky pre-commit runs `lint-staged` (`pnpm format` + `pnpm lint --fix`); set `HUSKY=0` to skip during bulk installs.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds `AGENTS.md` with Cursor Cloud-specific instructions discovered during VM environment setup.

## Highlights

- Documents Docker/Postgres startup, env file setup, and standard lint/test/dev commands
- Notes the fresh-database migration gotcha (`pnpm db:migrate` vs `drizzle-kit push`)
- Documents `ANTEATER_API_KEY` requirement for `pnpm get-data` and live WebSoc

## VM verification (this session)

| Check | Result |
|-------|--------|
| `pnpm install --frozen-lockfile` | ✅ |
| `pnpm lint` | ✅ 0 warnings |
| `pnpm test run` | ✅ 48/48 passed |
| `pnpm build` (antalmanac) | ✅ |
| `pnpm dev` @ :3000 | ✅ HTTP 200 |
| Course search autocomplete | ✅ (with stub generated data) |

**Update script:** `HUSKY=0 pnpm install --frozen-lockfile`

[antalmanac-dev-environment-demo.mp4](https://cursor.com/agents/bc-833d9b20-53d9-49d0-a70e-edd8922d0586/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fantalmanac-dev-environment-demo.mp4)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-833d9b20-53d9-49d0-a70e-edd8922d0586"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-833d9b20-53d9-49d0-a70e-edd8922d0586"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

